### PR TITLE
Remove reference to deleted test

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required (VERSION 3.0) # The minimum version of CMake necessary to build this project
 project (examples) # The name of our project
 
-declare_trisycl_test(TARGET demo_parallel_matrices_add)
 declare_trisycl_test(TARGET demo_parallel_matrix_add)
 declare_trisycl_test(TARGET parallel_matrix_add TEST_REGEX "3 5 7 9 11 13")
 declare_trisycl_test(TARGET parallel_vector_add TEST_REGEX "6 8 11")


### PR DESCRIPTION
Build was failing because a previous commit removed  the demo_parallel_matrices_add example source file without removing it's build target.