### PR TITLE
Handle all MSVC level 4 warnings (issue #19)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4267") # warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
     add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
     add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
-    add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
+    #add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
     #add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used
     #add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced
 
     # Disabling Warning Level 4 output
-    add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter
+    #add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter
     #add_compile_options("/wd4459") # warning C4459: declaration of '<id>' hides global declaration
     #add_compile_options("/wd4127") # warning C4127: conditional expression is constant
     #add_compile_options("/wd4456") # warning C4456: declaration of '<id>' hides previous local declaration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
 
     # Disabling Warning Level 4 output
     add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter
-    add_compile_options("/wd4459") # warning C4459: declaration of '<id>' hides global declaration
+    #add_compile_options("/wd4459") # warning C4459: declaration of '<id>' hides global declaration
     #add_compile_options("/wd4127") # warning C4127: conditional expression is constant
     #add_compile_options("/wd4456") # warning C4456: declaration of '<id>' hides previous local declaration
   endif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,14 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     find_package(Threads REQUIRED)
   endif(APPLE)
 
+  if(WIN32)
+    if(CMAKE_VERSION MATCHES "MSVC")
+      message(STATUS "Visual Studio IDE integration detected.")
+	  message(STATUS "Disabling CMake's automatic reconfiguration in favor of IDE detection.")
+	  set(CMAKE_SUPPRESS_REGENERATION ON CACHE BOOL "Disables pre-build rule of checking script timestamps")
+	endif(CMAKE_VERSION MATCHES "MSVC")
+  endif(WIN32)
+
 #
 # Set compiler-specific variables
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
 
     # Disabling (default) Warning Level 3 output
     add_compile_options("/wd4996") # warning C4996: Call to '<algorithm name>' with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct.
-    add_compile_options("/wd4267") # warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
+    #add_compile_options("/wd4267") # warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
     #add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
     #add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
     #add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
     add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
     add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
-    add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used
+    #add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used
     #add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced
 
     # Disabling Warning Level 4 output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     # Disabling (default) Warning Level 3 output
     add_compile_options("/wd4996") # warning C4996: Call to '<algorithm name>' with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct.
     add_compile_options("/wd4267") # warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
-    add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
+    #add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
     #add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
     #add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
     #add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     # Disabling Warning Level 4 output
     add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter
     add_compile_options("/wd4459") # warning C4459: declaration of '<id>' hides global declaration
-    add_compile_options("/wd4127") # warning C4127: conditional expression is constant
+    #add_compile_options("/wd4127") # warning C4127: conditional expression is constant
     #add_compile_options("/wd4456") # warning C4456: declaration of '<id>' hides previous local declaration
   endif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
     add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
     add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used
-    add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced
+    #add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced
 
     # Disabling Warning Level 4 output
     #add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4996") # warning C4996: Call to '<algorithm name>' with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct.
     add_compile_options("/wd4267") # warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
     add_compile_options("/wd4244") # warning C4244: '=': conversion from 'size_t' to 'double', possible loss of data
-    add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
+    #add_compile_options("/wd4305") # warning C4305: '<op>': truncation from 'double' to 'float'
     #add_compile_options("/wd4101") # warning C4101: '<id>': unreferenced local variable
     #add_compile_options("/wd4700") # warning C4700: uninitialized local variable '<id>' used
     #add_compile_options("/wd4189") # warning C4189: '<id>': local variable is initialized but not referenced

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ project(triSYCL C CXX) # The name of the project (forward declare language )
     add_compile_options("/wd4100") # warning C4100: '<param>': unreferenced formal parameter
     add_compile_options("/wd4459") # warning C4459: declaration of '<id>' hides global declaration
     add_compile_options("/wd4127") # warning C4127: conditional expression is constant
-    add_compile_options("/wd4456") # warning C4456: declaration of '<id>' hides previous local declaration
+    #add_compile_options("/wd4456") # warning C4456: declaration of '<id>' hides previous local declaration
   endif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
   # If compiling with g++

--- a/include/CL/sycl/accessor/detail/local_accessor.hpp
+++ b/include/CL/sycl/accessor/detail/local_accessor.hpp
@@ -106,7 +106,7 @@ public:
       template parm
   */
   accessor(const range<Dimensions> &allocation_size,
-           handler &command_group_handler) :
+           handler& /*command_group_handler*/) :
     array { allocation_size } {}
 
 

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -377,7 +377,7 @@ public:
                   "get_access(handler) can only deal with access::global_buffer"
                   " or access::constant_buffer (for host_buffer accessor"
                   " do not use a command group handler");
-    implementation->implementation->template track_access_mode<Mode, Target>();
+    implementation->implementation->template track_access_mode<Mode>();
     return { *this, command_group_handler };
   }
 
@@ -405,7 +405,7 @@ public:
     static_assert(Target == access::target::host_buffer,
                   "get_access() without a command group handler is only"
                   " for host_buffer accessor");
-    implementation->implementation->template track_access_mode<Mode, Target>();
+    implementation->implementation->template track_access_mode<Mode>();
     return { *this };
   }
 

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -113,7 +113,14 @@ public:
   buffer(const range<Dimensions> &r, Allocator allocator = {})
     : implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
                          { r }) }
-      {}
+  {
+    /** warning C4100: 'allocator': unreferenced formal parameter
+
+    Why don't we use the allocator when the API suggests it should
+    be used (moreover modified) inside the function body?
+    */
+    allocator;
+  }
 
 
   /** Create a new buffer with associated host memory
@@ -148,7 +155,14 @@ public:
          Allocator allocator = {})
     : implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
                          { host_data, r }) }
-  {}
+  {
+    /** warning C4100: 'allocator': unreferenced formal parameter
+
+    Why don't we use the allocator when the API suggests it should
+    be used (moreover modified) inside the function body?
+    */
+    allocator;
+  }
 
 
   /** Create a new buffer with associated host memory
@@ -172,7 +186,14 @@ public:
          Allocator allocator = {})
     : implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
                          { host_data, r }) }
-  {}
+  {
+    /** warning C4100: 'allocator': unreferenced formal parameter
+
+        Why don't we use the allocator when the API suggests it should
+        be used (moreover modified) inside the function body?
+    */
+    allocator;
+  }
 
 
   /** Create a new buffer with associated memory, using the data in
@@ -229,7 +250,14 @@ public:
          Allocator allocator = {})
     : implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
                          { host_data, buffer_range }) }
-  {}
+  {
+    /** warning C4100: 'allocator': unreferenced formal parameter
+
+    Why don't we use the allocator when the API suggests it should
+    be used (moreover modified) inside the function body?
+    */
+    allocator;
+  }
 
 
   /** Create a new buffer which is initialized by host_data
@@ -301,7 +329,14 @@ public:
          Allocator allocator = {}) :
     implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
                        { start_iterator, end_iterator }) }
-  {}
+  {
+    /** warning C4100: 'allocator': unreferenced formal parameter
+
+    Why don't we use the allocator when the API suggests it should
+    be used (moreover modified) inside the function body?
+    */
+    allocator;
+  }
 
 
   /** Create a new sub-buffer without allocation to have separate

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -59,7 +59,7 @@ private:
   // \todo Replace U and D somehow by T and Dimensions
   // To allow allocation access
   template <typename U,
-            std::size_t D,
+            int D,
             access::mode Mode,
             access::target Target /* = access::global_buffer */>
     friend class detail::accessor;

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -177,7 +177,7 @@ public:
   template <typename Iterator>
   buffer(Iterator start_iterator, Iterator end_iterator) :
     // The size of a multi_array is set at creation time
-    allocation { boost::extents[std::distance(start_iterator, end_iterator)] },
+    allocation{ boost::multi_array_types::extent_gen{}[std::distance(start_iterator, end_iterator)] },
     access { allocation }
     // If iterators are const ones, then we do not write back
     {

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -227,26 +227,24 @@ public:
   /** This method is to be called whenever an acessor is created.
       Its current purpose is to track if an accessor with write access
       is created and acting acordingly.
+
+      Static dispatch to handling access mode.
    */
-  template <access::mode Mode,
-            access::target Target = access::target::host_buffer>
+  template <access::mode Mode>
   void track_access_mode() {
-    // test if write access is required
-    if (   Mode == access::mode::write
-        || Mode == access::mode::read_write
-        || Mode == access::mode::discard_write
-        || Mode == access::mode::discard_read_write
-        || Mode == access::mode::atomic
-       ) {
-      modified = true;
-      if (copy_if_modified) {
-        copy_if_modified = false;
-        data_host = false;
-        allocation = boost::multi_array<T, Dimensions> { access };
-        access = boost::multi_array_ref<T, Dimensions> { allocation };
-      }
+    modified = true;
+    if (copy_if_modified) {
+      copy_if_modified = false;
+      data_host = false;
+      allocation = boost::multi_array<T, Dimensions> { access };
+      access = boost::multi_array_ref<T, Dimensions> { allocation };
     }
   }
+
+  /** Template specialization implementing the no op branch
+  */
+  template <>
+  void track_access_mode<access::mode::read>() {}
 
 
  /** Return a range object representing the size of the buffer in

--- a/include/CL/sycl/context.hpp
+++ b/include/CL/sycl/context.hpp
@@ -88,7 +88,7 @@ public:
      Return synchronous errors via the SYCL exception class and
      asynchronous errors are handled via the async_handler, if provided.
   */
-  context(cl_context clContext, async_handler asyncHandler = nullptr) {
+  context(cl_context /*clContext*/, async_handler asyncHandler = nullptr) {
     detail::unimplemented();
   }
 #endif
@@ -101,8 +101,8 @@ public:
       Return synchronous errors via the SYCL exception class and
       asynchronous errors are handled via the async_handler, if provided.
   */
-  context(const device_selector &deviceSelector,
-          info::gl_context_interop interopFlag,
+  context(const device_selector& /*deviceSelector*/,
+          info::gl_context_interop /*interopFlag*/,
           async_handler asyncHandler = nullptr) {
     detail::unimplemented();
   }
@@ -113,8 +113,8 @@ public:
       Return synchronous errors via the SYCL exception class and
       asynchronous errors are handled via the async_handler, if provided.
   */
-  context(const device &dev,
-          info::gl_context_interop interopFlag,
+  context(const device& /*dev*/,
+          info::gl_context_interop /*interopFlag*/,
           async_handler asyncHandler = nullptr) {
     detail::unimplemented();
   }
@@ -125,8 +125,8 @@ public:
       Return synchronous errors via the SYCL exception class and
       asynchronous errors are handled via the async_handler, if provided.
   */
-  context(const platform &plt,
-          info::gl_context_interop interopFlag,
+  context(const platform& /*plt*/,
+          info::gl_context_interop /*interopFlag*/,
           async_handler asyncHandler = nullptr) {
     detail::unimplemented();
   }
@@ -140,8 +140,8 @@ public:
      \todo Update the specification to replace vector by collection
      concept.
   */
-  context(const vector_class<device> &deviceList,
-          info::gl_context_interop interopFlag,
+  context(const vector_class<device>& /*deviceList*/,
+          info::gl_context_interop /*interopFlag*/,
           async_handler asyncHandler = nullptr) {
     detail::unimplemented();
   }

--- a/include/CL/sycl/detail/linear_id.hpp
+++ b/include/CL/sycl/detail/linear_id.hpp
@@ -32,7 +32,7 @@ size_t constexpr inline linear_id(Range range, Id id, Id offset = {}) {
   /* A good compiler should unroll this and do partial evaluation to
      remove the first multiplication by 0 of this Horner evaluation and
      remove the 0 offset evaluation */
-    for (int i = dims - 1; i >= 0; --i)
+    for (decltype(dims) i = dims - 1; i >= 0; --i)
       linear_id = linear_id*range[i] + id[i] - offset[i];
 
     return linear_id;

--- a/include/CL/sycl/device/detail/host_device.hpp
+++ b/include/CL/sycl/device/detail/host_device.hpp
@@ -99,7 +99,7 @@ public:
 
       \todo To be implemented
   */
-  bool has_extension(const string_class &extension) const override {
+  bool has_extension(const string_class& /*extension*/) const override {
     detail::unimplemented();
     return {};
   }

--- a/include/CL/sycl/device/detail/opencl_device.hpp
+++ b/include/CL/sycl/device/detail/opencl_device.hpp
@@ -101,7 +101,7 @@ public:
 
       \todo To be implemented
   */
-  bool has_extension(const string_class &extension) const override {
+  bool has_extension(const string_class& /*extension*/) const override {
     detail::unimplemented();
     return {};
   }

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -132,6 +132,8 @@ private:
     };
     // Remove the warning about unused variable
     static_cast<void>(just_to_evaluate);
+    // Empty set_args() leaves 't' unreferenced, triggering warning C4189
+    static_cast<void>(t);
   }
 
 public:

--- a/include/CL/sycl/nd_item.hpp
+++ b/include/CL/sycl/nd_item.hpp
@@ -198,6 +198,10 @@ public:
   */
   void barrier(access::fence_space flag =
                access::fence_space::global_and_local) const {
+    /** warning C4100: 'flag': unreferenced formal parameter
+    */
+    flag;
+
 #if defined(_OPENMP) && !defined(TRISYCL_NO_BARRIER)
     /* Use OpenMP barrier in the implementation with 1 OpenMP thread per
        work-item of the work-group */

--- a/include/CL/sycl/parallelism/detail/parallelism.hpp
+++ b/include/CL/sycl/parallelism/detail/parallelism.hpp
@@ -107,7 +107,7 @@ struct parallel_OpenMP_for_iterate {
     kernel functor with the constructed id */
 template <typename Range, typename ParallelForFunctor, typename Id>
 struct parallel_for_iterate<0, Range, ParallelForFunctor, Id> {
-  parallel_for_iterate(Range r, ParallelForFunctor &f, Id &index) {
+  parallel_for_iterate(Range /*r*/, ParallelForFunctor &f, Id &index) {
     f(index);
   }
 };
@@ -224,7 +224,7 @@ void parallel_for(nd_range<Dimensions> r,
   range<Dimensions> local_range = r.get_local();
 
   // Reconstruct the nd_item from its group and local id
-  auto reconstruct_item = [&] (id<Dimensions> l) {
+  auto reconstruct_item = [&] (id<Dimensions> /*l*/) {
     //local.display();
     // Reconstruct the global nd_item
     index.set_local(local);
@@ -237,7 +237,7 @@ void parallel_for(nd_range<Dimensions> r,
   /* To recycle the parallel_for on range<>, wrap the ParallelForFunctor f
      into another functor that iterates inside the work-group and then
      calls f */
-  auto iterate_in_work_group = [&] (id<Dimensions> g) {
+  auto iterate_in_work_group = [&] (id<Dimensions> /*g*/) {
     //group.display();
     // Then iterate on the local work-groups
     parallel_for_iterate<Dimensions,
@@ -339,7 +339,7 @@ void parallel_for_workitem(const group<Dimensions> &g,
   id<Dimensions> local;
 
   // Reconstruct the nd_item from its group and local id
-  auto reconstruct_item = [&] (id<Dimensions> l) {
+  auto reconstruct_item = [&] (id<Dimensions> /*l*/) {
     //local.display();
     //l.display();
     // Reconstruct the global nd_item

--- a/include/CL/sycl/pipe/detail/pipe_accessor.hpp
+++ b/include/CL/sycl/pipe/detail/pipe_accessor.hpp
@@ -104,7 +104,7 @@ public:
   /** Construct a pipe accessor from an existing pipe
    */
   pipe_accessor(const std::shared_ptr<detail::pipe<T>> &p,
-                handler &command_group_handler) :
+                handler& /*command_group_handler*/) :
     implementation { p } {
     //    TRISYCL_DUMP_T("Create a kernel pipe accessor write = "
     //                 << is_write_access());

--- a/include/CL/sycl/pipe/detail/pipe_accessor.hpp
+++ b/include/CL/sycl/pipe/detail/pipe_accessor.hpp
@@ -76,6 +76,29 @@ private:
   */
   bool mutable ok = false;
 
+  template <access::mode Mode> void ctor_dispatch() {
+    if (implementation->used_for_reading)
+      throw std::logic_error{ "The pipe is already used for reading." };
+    else
+      implementation->used_for_reading = true;
+  }
+
+  template <> void ctor_dispatch<access::mode::write>() {
+    if (implementation->used_for_writing)
+      /// \todo Use pipe_exception instead
+      throw std::logic_error{ "The pipe is already used for writing." };
+    else
+      implementation->used_for_writing = true;
+  }
+
+  template <access::mode Mode> void dtor_dispatch() {
+    implementation->used_for_reading = false;
+  }
+
+  template <> void dtor_dispatch<access::mode::write>() {
+    implementation->used_for_writing = false;
+  }
+
 public:
 
   /** Construct a pipe accessor from an existing pipe
@@ -86,17 +109,18 @@ public:
     //    TRISYCL_DUMP_T("Create a kernel pipe accessor write = "
     //                 << is_write_access());
     // Verify that the pipe is not already used in the requested mode
-    if (mode == access::mode::write)
-      if (implementation->used_for_writing)
-        /// \todo Use pipe_exception instead
-        throw std::logic_error { "The pipe is already used for writing." };
-      else
-        implementation->used_for_writing = true;
-    else
-      if (implementation->used_for_reading)
-        throw std::logic_error { "The pipe is already used for reading." };
-      else
-        implementation->used_for_reading = true;
+    ctor_dispatch<mode>();
+    //if (mode == access::mode::write)
+    //  if (implementation->used_for_writing)
+    //    /// \todo Use pipe_exception instead
+    //    throw std::logic_error { "The pipe is already used for writing." };
+    //  else
+    //    implementation->used_for_writing = true;
+    //else
+    //  if (implementation->used_for_reading)
+    //    throw std::logic_error { "The pipe is already used for reading." };
+    //  else
+    //    implementation->used_for_reading = true;
   }
 
 
@@ -271,10 +295,11 @@ public:
 
   ~pipe_accessor() {
     /// Free the pipe for a future usage for the current mode
-    if (mode == access::mode::write)
-      implementation->used_for_writing = false;
-    else
-      implementation->used_for_reading = false;
+    dtor_dispatch<mode>();
+    //if (mode == access::mode::write)
+    //  implementation->used_for_writing = false;
+    //else
+    //  implementation->used_for_reading = false;
   }
 
 };

--- a/include/CL/sycl/platform.hpp
+++ b/include/CL/sycl/platform.hpp
@@ -89,7 +89,7 @@ public:
 
        Returns errors via the SYCL exception class.
   */
-  explicit platform(const device_selector &dev_selector) {
+  explicit platform(const device_selector& /*dev_selector*/) {
     detail::unimplemented();
   }
 

--- a/include/CL/sycl/platform/detail/host_platform.hpp
+++ b/include/CL/sycl/platform/detail/host_platform.hpp
@@ -108,7 +108,7 @@ public:
 
       \todo To be implemented
   */
-  bool has_extension(const string_class &extension) const override {
+  bool has_extension(const string_class& /*extension*/) const override {
     detail::unimplemented();
     return {};
   }

--- a/include/CL/sycl/queue.hpp
+++ b/include/CL/sycl/queue.hpp
@@ -133,7 +133,7 @@ public:
       report asynchronous errors via the async_handler callback
       function if and only if there is an async_handler provided.
   */
-  queue(const device_selector &deviceSelector,
+  queue(const device_selector& /*deviceSelector*/,
         async_handler asyncHandler = nullptr) : queue { } {
     detail::unimplemented();
   }
@@ -143,7 +143,7 @@ public:
 
       Return asynchronous errors via the async_handler callback function.
   */
-  queue(const device &syclDevice,
+  queue(const device& /*syclDevice*/,
         async_handler asyncHandler = nullptr) : queue { } {
     detail::unimplemented();
   };
@@ -160,8 +160,8 @@ public:
       asynchronous errors via the async_handler callback function in
       conjunction with the synchronization and throw methods.
   */
-  queue(const context &syclContext,
-        const device_selector &deviceSelector,
+  queue(const context& /*syclContext*/,
+        const device_selector& /*deviceSelector*/,
         async_handler asyncHandler = nullptr) : queue { } {
     detail::unimplemented();
   }
@@ -176,8 +176,8 @@ public:
       asynchronous errors via the async_handler callback function in
       conjunction with the synchronization and throw methods.
   */
-  queue(const context &syclContext,
-        const device &syclDevice,
+  queue(const context& /*syclContext*/,
+        const device& /*syclDevice*/,
         async_handler asyncHandler = nullptr) : queue { } {
     detail::unimplemented();
   }
@@ -194,9 +194,9 @@ public:
       asynchronous errors via the async_handler callback function in
       conjunction with the synchronization and throw methods.
   */
-  queue(const context &syclContext,
-        const device &syclDevice,
-        info::queue_profiling profilingFlag,
+  queue(const context& /*syclContext*/,
+        const device& /*syclDevice*/,
+        info::queue_profiling /*profilingFlag*/,
         async_handler asyncHandler = nullptr) : queue { } {
     detail::unimplemented();
   }
@@ -343,7 +343,7 @@ public:
       Return a command group functor event, which is corresponds to the
       queue the command group functor is being enqueued on.
   */
-  handler_event submit(std::function<void(handler &)> cgf, queue &secondaryQueue) {
+  handler_event submit(std::function<void(handler &)> cgf, queue& /*secondaryQueue*/) {
     detail::unimplemented();
     // Since it is not implemented, always submit on the main queue
     return submit(cgf);

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -54,7 +54,7 @@ public:
     // Return the product of the sizes in each dimension
     return std::accumulate(this->cbegin(),
                            this->cend(),
-                           1,
+                           static_cast<size_t>(1),
                            std::multiplies<size_t> {});
   }
 };

--- a/tests/2014-04-21-HPC-GPU_Meetup/slide_23.cpp
+++ b/tests/2014-04-21-HPC-GPU_Meetup/slide_23.cpp
@@ -10,7 +10,7 @@
 // To have FunctionObject working without explicit closure, put the
 // accessor as a global variable. But that means to pull many things as a
 // global variable...
-int result; //< this is where we will write our result
+
 // wrap our result variable in a buffer
 cl::sycl::buffer<int> resultBuf(1);
 
@@ -25,6 +25,7 @@ struct FunctionObject {
 };
 int main()
 {
+  int result; //< this is where we will write our result
 
   { // by sticking all the SYCL work in a {} block, we ensure
     // all SYCL tasks must complete before exiting the block

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,8 @@ function(declare_trisycl_test)
   target_compile_definitions(${TARGET_NAME} PUBLIC $<$<BOOL:${TRISYCL_NO_ASYNC}>:TRISYCL_NO_ASYNC> # If opting for synchronous task exec
                                                    $<$<BOOL:${declare_trisycl_test_USES_OPENCL}>:TRISYCL_OPENCL> # If the test uses OpenCL
                                                    $<$<BOOL:${TRISYCL_DEBUG}>:TRISYCL_DEBUG>
-                                                   $<$<BOOL:${TRISYCL_DEBUG_STRUCTORS}>:TRISYCL_DEBUG_STRUCTORS>)
+                                                   $<$<BOOL:${TRISYCL_DEBUG_STRUCTORS}>:TRISYCL_DEBUG_STRUCTORS>
+												   $<$<BOOL:${WIN32}>:BOOST_MULTI_ARRAY_NO_GENERATORS>)
 
   # OpenMP requirements
   target_compile_options(${TARGET_NAME} PUBLIC $<$<BOOL:${TRISYCL_OPENMP}>:${OpenMP_CXX_FLAGS}>)

--- a/tests/accessor/accessor.cpp
+++ b/tests/accessor/accessor.cpp
@@ -8,17 +8,17 @@
 
 using namespace cl::sycl;
 
-// Size of the buffers
-constexpr size_t N = 20;
-constexpr size_t M = 30;
-constexpr size_t P = 40;
-
 #define TEST_TYPE(accessor_var, type_member, type)                      \
   static_assert(std::is_same<type,                                      \
                 decltype(accessor_var)::type_member>::value,            \
                 #type_member " is an " #type)
 
 int main() {
+    // Size of the buffers
+    constexpr size_t N = 20;
+    constexpr size_t M = 30;
+    constexpr size_t P = 40;
+
     // Create read-write buffers for each rank
     cl::sycl::buffer<int, 1> a(N);
     cl::sycl::buffer<int, 2> b({ N, M });

--- a/tests/accessor/accessor_sizes.cpp
+++ b/tests/accessor/accessor_sizes.cpp
@@ -19,7 +19,7 @@ using namespace cl::sycl;
               == a.get_count()*sizeof(decltype(a)::value_type));
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   range<1> r1 { 8 };
   buffer<double> b1 { r1 };
   CHECK_RANGE_ACCESSOR(r1, (b1.get_access<access::mode::read_write,

--- a/tests/accessor/accessor_sizes.cpp
+++ b/tests/accessor/accessor_sizes.cpp
@@ -19,7 +19,7 @@ using namespace cl::sycl;
               == a.get_count()*sizeof(decltype(a)::value_type));
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   range<1> r1 { 8 };
   buffer<double> b1 { r1 };
   CHECK_RANGE_ACCESSOR(r1, (b1.get_access<access::mode::read_write,

--- a/tests/accessor/demo_parallel_matrix_add.cpp
+++ b/tests/accessor/demo_parallel_matrix_add.cpp
@@ -7,11 +7,12 @@
 
 using namespace cl::sycl;
 
-// Size of the matrices
-const size_t N = 2000;
-const size_t M = 3000;
 
 int main() {
+  // Size of the matrices
+  const size_t N = 2000;
+  const size_t M = 3000;
+
   { // By sticking all the SYCL work in a {} block, we ensure
     // all SYCL tasks must complete before exiting the block
 

--- a/tests/accessor/demo_parallel_matrix_add.cpp
+++ b/tests/accessor/demo_parallel_matrix_add.cpp
@@ -32,7 +32,9 @@ int main() {
         // Enqueue a parallel kernel iterating on a N*M 2D iteration space
         cgh.parallel_for<class init_a>({ N, M },
                                        [=] (id<2> index) {
-                                         A[index] = index[0]*2 + index[1];
+                                         // cast silences warning of implicit cast between integral
+                                         // and floating types. Promise is made that no data is lost
+                                         A[index] = static_cast<double>(index[0]*2 + index[1]);
                                        });
       });
 
@@ -47,7 +49,9 @@ int main() {
         // Enqueue a parallel kernel iterating on a N*M 2D iteration space
         cgh.parallel_for<class init_b>({ N, M },
                                        [=] (id<2> index) {
-                                         B[index] = index[0]*2014 + index[1]*42;
+                                         // cast silences warning of implicit cast between integral
+                                         // and floating types. Promise is made that no data is lost
+                                         B[index] = static_cast<double>(index[0]*2014 + index[1]*42);
                                        });
       });
 

--- a/tests/accessor/iterators.cpp
+++ b/tests/accessor/iterators.cpp
@@ -12,10 +12,11 @@
 // Actually zip_iterator.hpp requires this implementation of tuples...
 #include <boost/tuple/tuple.hpp>
 
-constexpr size_t N = 300;
-using Type = int;
 
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 300;
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/accessor/iterators.cpp
+++ b/tests/accessor/iterators.cpp
@@ -13,7 +13,7 @@
 #include <boost/tuple/tuple.hpp>
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/accessor/iterators.cpp
+++ b/tests/accessor/iterators.cpp
@@ -13,7 +13,7 @@
 #include <boost/tuple/tuple.hpp>
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/accessor/local_accessor_hierarchical_convolution.cpp
+++ b/tests/accessor/local_accessor_hierarchical_convolution.cpp
@@ -12,7 +12,7 @@
 using namespace cl::sycl;
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/accessor/local_accessor_hierarchical_convolution.cpp
+++ b/tests/accessor/local_accessor_hierarchical_convolution.cpp
@@ -11,11 +11,11 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 300;
-using Type = int;
-
 
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 300;
+  using Type = int;
+
   // The convolution kernel
   const std::vector<Type> conv_kernel_init = { 1, 2, 4 };
   buffer<Type> conv_kernel { conv_kernel_init.begin(),

--- a/tests/accessor/local_accessor_hierarchical_convolution.cpp
+++ b/tests/accessor/local_accessor_hierarchical_convolution.cpp
@@ -12,7 +12,7 @@
 using namespace cl::sycl;
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/address_spaces/address_spaces.cpp
+++ b/tests/address_spaces/address_spaces.cpp
@@ -20,9 +20,6 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 
 struct Range {
   float low, high;
@@ -36,6 +33,8 @@ static_assert(std::is_object<std::string>::value,
               "T must be a pointer type");
 
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
 
   float c[N];
 

--- a/tests/address_spaces/address_spaces.cpp
+++ b/tests/address_spaces/address_spaces.cpp
@@ -104,7 +104,7 @@ int main() {
           global_float = 7;
 
           global<float> global_float2 = global_float;
-          global_float2 += .1;
+          global_float2 += .1f;
           priv<double> priv_double = global_float;
           priv<double> priv_double2 { priv_double };
 

--- a/tests/address_spaces/address_spaces.cpp
+++ b/tests/address_spaces/address_spaces.cpp
@@ -92,6 +92,9 @@ int main() {
           *ppd = 5.5;
           auto p_c_p = make_multi(c_p);
           *ppd += *p_c_p;
+          // Silence unused local variable
+          static_cast<void>(g_p);
+          static_cast<void>(l_p);
 
           global<float> global_float;
           global_float = f[0];

--- a/tests/buffer/associative_containers.cpp
+++ b/tests/buffer/associative_containers.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   check_all<buffer<char, 3>>();
 
   return 0;

--- a/tests/buffer/associative_containers.cpp
+++ b/tests/buffer/associative_containers.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   check_all<buffer<char, 3>>();
 
   return 0;

--- a/tests/buffer/buffer_get_count.cpp
+++ b/tests/buffer/buffer_get_count.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   std::vector<int> v(10);
   size_t bufferSize = std::distance(v.begin(), v.end()); 
   std::shared_ptr<int> ptr { new int[bufferSize], std::default_delete<int[]>() };

--- a/tests/buffer/buffer_get_count.cpp
+++ b/tests/buffer/buffer_get_count.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   std::vector<int> v(10);
   size_t bufferSize = std::distance(v.begin(), v.end()); 
   std::shared_ptr<int> ptr { new int[bufferSize], std::default_delete<int[]>() };

--- a/tests/buffer/buffer_map_allocator.cpp
+++ b/tests/buffer/buffer_map_allocator.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr auto N = 16;
 

--- a/tests/buffer/buffer_map_allocator.cpp
+++ b/tests/buffer/buffer_map_allocator.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr auto N = 16;
 

--- a/tests/buffer/buffer_set_final_data.cpp
+++ b/tests/buffer/buffer_set_final_data.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/buffer_set_final_data.cpp
+++ b/tests/buffer/buffer_set_final_data.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/buffer_set_final_data_1.cpp
+++ b/tests/buffer/buffer_set_final_data_1.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr int N = 16;
   {
     std::vector<int> v(N);

--- a/tests/buffer/buffer_set_final_data_1.cpp
+++ b/tests/buffer/buffer_set_final_data_1.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr int N = 16;
   {
     std::vector<int> v(N);

--- a/tests/buffer/buffer_shared_ptr.cpp
+++ b/tests/buffer/buffer_shared_ptr.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/buffer_shared_ptr.cpp
+++ b/tests/buffer/buffer_shared_ptr.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/buffer_sizes.cpp
+++ b/tests/buffer/buffer_sizes.cpp
@@ -16,7 +16,7 @@ using namespace cl::sycl;
               == b.get_count()*sizeof(decltype(b)::value_type));
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   range<1> r1 { 8 };
   buffer<double> b1 { r1 };
   CHECK_RANGE_BUFFER(r1, b1);

--- a/tests/buffer/buffer_sizes.cpp
+++ b/tests/buffer/buffer_sizes.cpp
@@ -16,7 +16,7 @@ using namespace cl::sycl;
               == b.get_count()*sizeof(decltype(b)::value_type));
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   range<1> r1 { 8 };
   buffer<double> b1 { r1 };
   CHECK_RANGE_BUFFER(r1, b1);

--- a/tests/buffer/buffer_unique_ptr.cpp
+++ b/tests/buffer/buffer_unique_ptr.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/buffer_unique_ptr.cpp
+++ b/tests/buffer/buffer_unique_ptr.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr size_t N = 16;
 

--- a/tests/buffer/global_buffer.cpp
+++ b/tests/buffer/global_buffer.cpp
@@ -13,9 +13,6 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 2;
-constexpr size_t M = 3;
-using Matrix = float[N][M];
 
 // Test with global default buffers
 buffer<float, 2> A;
@@ -23,6 +20,10 @@ buffer<float, 2> B;
 buffer<float, 2> C;
 
 int main() {
+  constexpr size_t N = 2;
+  constexpr size_t M = 3;
+  using Matrix = float[N][M];
+
   Matrix a = { { 1, 2, 3 }, { 4, 5, 6 } };
   Matrix b = { { 2, 3, 4 }, { 5, 6, 7 } };
 

--- a/tests/buffer/global_buffer_set_final_data.cpp
+++ b/tests/buffer/global_buffer_set_final_data.cpp
@@ -11,7 +11,7 @@ using namespace cl::sycl;
 
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 16;
   
   buffer<int> buf{ N };

--- a/tests/buffer/global_buffer_set_final_data.cpp
+++ b/tests/buffer/global_buffer_set_final_data.cpp
@@ -9,11 +9,13 @@
 using namespace cl::sycl;
 
 
-constexpr size_t N = 16;
 
-buffer<int> b { N };
 
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 16;
+  
+  buffer<int> buf{ N };
+
   /** There is a draft for shared_ptr of arrays for C++17, but it is
       not here... So use a shared pointer with an explicit destructor
       waiting for 2017 */
@@ -21,26 +23,21 @@ int test_main(int argc, char *argv[]) {
 
   /* Note that here there is a nice implicit conversion happening
      from std::shared_ptr<int> to std::weak_ptr<int> */
-  b.set_final_data(result);
+  buf.set_final_data(result);
 
   queue {}.submit([&](handler &cgh) {
-      auto a = b.get_access<access::mode::write>(cgh);
+      auto a = buf.get_access<access::mode::write>(cgh);
 
       cgh.parallel_for<class generate>(range<1> { N },
                                        [=] (id<1> index) {
                                          a[index] = index;
                                        });
     });
-  /* Be careful with global buffers with copy back behaviour, since
-     the destructor is called at program exit (typically in some C++
-     library at_exit handler at a time the object to copy to may be
-     dead for a while, so with a lot of havoc and hard debug time...
-
-     So since we want the buffer destructor of b to copy back the
+  /* So since we want the buffer destructor of b to copy back the
      content just before using result, just reassign an empty buffer
      to b
   */
-  b = {};
+  buf = {};
   for (int i = 0; i != N; ++i) {
     // std::cerr << result.get()[i] << ':' << i << std::endl;
     BOOST_CHECK(result.get()[i] == i);

--- a/tests/buffer/global_buffer_set_final_data.cpp
+++ b/tests/buffer/global_buffer_set_final_data.cpp
@@ -9,13 +9,11 @@
 using namespace cl::sycl;
 
 
+constexpr size_t N = 16;
 
+buffer<int> buf{ N };
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
-  constexpr size_t N = 16;
-  
-  buffer<int> buf{ N };
-
+int test_main(int /*argc*/, char*[] /*argv*/) {
   /** There is a draft for shared_ptr of arrays for C++17, but it is
       not here... So use a shared pointer with an explicit destructor
       waiting for 2017 */

--- a/tests/buffer/shared_buffer.cpp
+++ b/tests/buffer/shared_buffer.cpp
@@ -10,12 +10,13 @@
 
 using namespace cl::sycl;
 
-// Size of the buffers
-constexpr size_t N = 20;
 
 
 // To verify it works through function return
 cl::sycl::buffer<int, 1> f(void) {
+  // Size of the buffers
+  constexpr size_t N = 20;
+
   // Create a read-write 1D buffer of size N
   cl::sycl::buffer<int, 1> a(N);
   DISPLAY_BUFFER_USE_COUNT(a);

--- a/tests/common/check_throwing_get.hpp
+++ b/tests/common/check_throwing_get.hpp
@@ -3,7 +3,11 @@
 */
 
 template <typename T>
-void check_throwing_get(const T &o) {
+void check_throwing_get(const T&
+#ifdef TRISYCL_OPENCL
+    o
+#endif
+) {
 // Some OpenCL specific tests
 #ifdef TRISYCL_OPENCL
   bool exception_seen = false;

--- a/tests/common/test-helpers.hpp
+++ b/tests/common/test-helpers.hpp
@@ -22,7 +22,7 @@ struct trisycl_for_range_iterate {
 /// Once at level 0, just call the final function with the current coordinate
 template <int Dimensions, typename Functor>
 struct trisycl_for_range_iterate<Dimensions, Functor, 0> {
-  trisycl_for_range_iterate(const cl::sycl::range<Dimensions> &r,
+  trisycl_for_range_iterate(const cl::sycl::range<Dimensions>& /*r*/,
                             cl::sycl::id<Dimensions> &it,
                             const Functor &f) {
     f(it);

--- a/tests/detail/small_array.cpp
+++ b/tests/detail/small_array.cpp
@@ -36,7 +36,7 @@ bool equal(const detail::small_array<T, U, N, true> &v,
 }
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   sa1 a;
   sa1 a1 { 3 };
   BOOST_CHECK(a1[0] == 3);

--- a/tests/detail/small_array.cpp
+++ b/tests/detail/small_array.cpp
@@ -36,7 +36,7 @@ bool equal(const detail::small_array<T, U, N, true> &v,
 }
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   sa1 a;
   sa1 a1 { 3 };
   BOOST_CHECK(a1[0] == 3);

--- a/tests/device/default_device.cpp
+++ b/tests/device/default_device.cpp
@@ -14,7 +14,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Create a default device which is the host device
   device d;
 

--- a/tests/device/default_device.cpp
+++ b/tests/device/default_device.cpp
@@ -14,7 +14,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Create a default device which is the host device
   device d;
 

--- a/tests/device/get_info.cpp
+++ b/tests/device/get_info.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Get all the devices
   auto devices = device::get_devices();
   // Verify that the device_type returned match what is expected

--- a/tests/device/get_info.cpp
+++ b/tests/device/get_info.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Get all the devices
   auto devices = device::get_devices();
   // Verify that the device_type returned match what is expected

--- a/tests/device/opencl_device.cpp
+++ b/tests/device/opencl_device.cpp
@@ -15,7 +15,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Create an OpenCL device
   check_all<device>(boost::compute::system::devices()[0]);
 

--- a/tests/device/opencl_device.cpp
+++ b/tests/device/opencl_device.cpp
@@ -15,7 +15,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Create an OpenCL device
   check_all<device>(boost::compute::system::devices()[0]);
 

--- a/tests/device/type.cpp
+++ b/tests/device/type.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Get all the devices
   auto devices = device::get_devices();
   // Verify that the device_type returned match what is expected

--- a/tests/device/type.cpp
+++ b/tests/device/type.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Get all the devices
   auto devices = device::get_devices();
   // Verify that the device_type returned match what is expected

--- a/tests/device_selector/explicit_selector.cpp
+++ b/tests/device_selector/explicit_selector.cpp
@@ -26,7 +26,7 @@ void test_device(info::device_type type) {
 }
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   test_device<host_selector>(info::device_type::host);
   test_device<cpu_selector>(info::device_type::cpu);
   test_device<gpu_selector>(info::device_type::gpu);

--- a/tests/device_selector/explicit_selector.cpp
+++ b/tests/device_selector/explicit_selector.cpp
@@ -21,7 +21,7 @@ void test_device(info::device_type type) {
     BOOST_CHECK(f != ds.cend());
   }
   /// \todo put the final exception class here
-  catch (std::domain_error &e) {
+  catch (std::domain_error&) {
   }
 }
 

--- a/tests/device_selector/explicit_selector.cpp
+++ b/tests/device_selector/explicit_selector.cpp
@@ -26,7 +26,7 @@ void test_device(info::device_type type) {
 }
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   test_device<host_selector>(info::device_type::host);
   test_device<cpu_selector>(info::device_type::cpu);
   test_device<gpu_selector>(info::device_type::gpu);

--- a/tests/device_selector/opencl_selector.cpp
+++ b/tests/device_selector/opencl_selector.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Get all the devices from the given device_type
   auto opencl_devices = device::get_devices(info::device_type::opencl);
   auto all_devices = device::get_devices();

--- a/tests/device_selector/opencl_selector.cpp
+++ b/tests/device_selector/opencl_selector.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Get all the devices from the given device_type
   auto opencl_devices = device::get_devices(info::device_type::opencl);
   auto all_devices = device::get_devices();

--- a/tests/device_selector/selector.cpp
+++ b/tests/device_selector/selector.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // For all device_type
   for (auto const &t : { info::device_type::host,
                          info::device_type::cpu,

--- a/tests/device_selector/selector.cpp
+++ b/tests/device_selector/selector.cpp
@@ -6,7 +6,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // For all device_type
   for (auto const &t : { info::device_type::host,
                          info::device_type::cpu,

--- a/tests/examples/demo_parallel_matrices_add.cpp
+++ b/tests/examples/demo_parallel_matrices_add.cpp
@@ -5,11 +5,12 @@
 
 using namespace cl::sycl;
 
-// Size of the matrices
-const size_t N = 2000;
-const size_t M = 3000;
 
 int main() {
+  // Size of the matrices
+  const size_t N = 2000;
+  const size_t M = 3000;
+
   // Create a queue to work on
   queue myQueue;
 

--- a/tests/examples/demo_parallel_matrices_add.cpp
+++ b/tests/examples/demo_parallel_matrices_add.cpp
@@ -27,7 +27,9 @@ int main() {
       // Enqueue a parallel kernel iterating on a N*M 2D iteration space
       cgh.parallel_for<class init_a>({ N, M },
                                      [=] (id<2> index) {
-                                       A[index] = index[0]*2 + index[1];
+                                       // cast silences warning of implicit cast between integral
+                                       // and floating types. Promise is made that no data is lost
+                                       A[index] = static_cast<double>(index[0]*2 + index[1]);
                                      });
     });
 
@@ -42,7 +44,9 @@ int main() {
       // Enqueue a parallel kernel iterating on a N*M 2D iteration space
       cgh.parallel_for<class init_b>({ N, M },
                                      [=] (id<2> index) {
-                                       B[index] = index[0]*2014 + index[1]*42;
+                                       // cast silences warning of implicit cast between integral
+                                       // and floating types. Promise is made that no data is lost
+                                       B[index] = static_cast<double>(index[0]*2014 + index[1]*42);
                                      });
     });
 

--- a/tests/examples/demo_parallel_matrix_add.cpp
+++ b/tests/examples/demo_parallel_matrix_add.cpp
@@ -30,7 +30,9 @@ int main() {
         // Enqueue a parallel kernel iterating on a N*M 2D iteration space
         cgh.parallel_for<class init_a>({ N, M },
                                        [=] (id<2> index) {
-                                         A[index] = index[0]*2 + index[1];
+                                         // cast silences warning of implicit cast between integral
+                                         // and floating types. Promise is made that no data is lost
+                                         A[index] = static_cast<double>(index[0]*2 + index[1]);
                                        });
       });
 
@@ -45,7 +47,9 @@ int main() {
         // Enqueue a parallel kernel iterating on a N*M 2D iteration space
         cgh.parallel_for<class init_b>({ N, M },
                                        [=] (id<2> index) {
-                                         B[index] = index[0]*2014 + index[1]*42;
+                                         // cast silences warning of implicit cast between integral
+                                         // and floating types. Promise is made that no data is lost
+                                         B[index] = static_cast<double>(index[0]*2014 + index[1]*42);
                                        });
       });
 

--- a/tests/examples/demo_parallel_matrix_add.cpp
+++ b/tests/examples/demo_parallel_matrix_add.cpp
@@ -5,11 +5,12 @@
 
 using namespace cl::sycl;
 
-// Size of the matrices
-const size_t N = 2000;
-const size_t M = 3000;
 
 int main() {
+  // Size of the matrices
+  const size_t N = 2000;
+  const size_t M = 3000;
+
   { // By sticking all the SYCL work in a {} block, we ensure
     // all SYCL tasks must complete before exiting the block
 

--- a/tests/examples/parallel_matrix_add.cpp
+++ b/tests/examples/parallel_matrix_add.cpp
@@ -11,11 +11,12 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 2;
-constexpr size_t M = 3;
-using Matrix = float[N][M];
 
 int main() {
+  constexpr size_t N = 2;
+  constexpr size_t M = 3;
+  using Matrix = float[N][M];
+
   Matrix a = { { 1, 2, 3 }, { 4, 5, 6 } };
   Matrix b = { { 2, 3, 4 }, { 5, 6, 7 } };
 

--- a/tests/examples/parallel_vector_add.cpp
+++ b/tests/examples/parallel_vector_add.cpp
@@ -8,10 +8,10 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/examples/simpler_parallel_matrix_add.cpp
+++ b/tests/examples/simpler_parallel_matrix_add.cpp
@@ -6,12 +6,13 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 2;
-constexpr size_t M = 3;
-using Matrix = float[N][M];
 
 // Compute sum of matrices a and b into c
 int main() {
+  constexpr size_t N = 2;
+  constexpr size_t M = 3;
+  using Matrix = float[N][M];
+
  Matrix a = { { 1, 2, 3 }, { 4, 5, 6 } };
  Matrix b = { { 2, 3, 4 }, { 5, 6, 7 } };
 

--- a/tests/examples/vector_add.cpp
+++ b/tests/examples/vector_add.cpp
@@ -7,10 +7,11 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
 
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
 

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -26,10 +26,9 @@ using namespace cl::sycl;
 
 
 int main() {
-  id<> i;
+  id<> i{ 1 };
   id<3> i3;
-  // Since i is not initialized, neither k
-  id<> k(i); // NOTE: MSVC throws exception here in Debug mode: Use of uninitialized variable 'i' (default constructed std::array holds indererminate values)
+  id<> k(i);
   (k - k).display();
   id<> j { 1 };
   i = j;

--- a/tests/id/id.cpp
+++ b/tests/id/id.cpp
@@ -63,7 +63,7 @@ int main() {
   for (auto const & e: jj)
     std::cout << "jj via e = " << e << std::endl;
 
-  std::vector<float> cjj(std::begin(jj), std::end(jj));
+  std::vector<std::size_t> cjj(std::begin(jj), std::end(jj));
 
   for (auto e: cjj)
     std::cout << "cjj via e = " << e << std::endl;

--- a/tests/jacobi/include/helpers-jacobi.hpp
+++ b/tests/jacobi/include/helpers-jacobi.hpp
@@ -171,13 +171,13 @@ inline void stop_papi_stencil(struct counters& timer){
 }
 
 #else // else #USE_PAPI
-inline void start_papi_loading(struct counters& timer){}
+inline void start_papi_loading(struct counters& /*timer*/){}
 
-inline void stop_papi_loading(struct counters& timer){}
+inline void stop_papi_loading(struct counters& /*timer*/){}
 
-inline void start_papi_stencil(struct counters& timer){}
+inline void start_papi_stencil(struct counters& /*timer*/){}
 
-inline void stop_papi_stencil(struct counters& timer){}
+inline void stop_papi_stencil(struct counters& /*timer*/){}
 
 
 #endif

--- a/tests/jacobi/include/helpers-jacobi.hpp
+++ b/tests/jacobi/include/helpers-jacobi.hpp
@@ -77,7 +77,7 @@ int es = PAPI_NULL; //event set
 
 size_t NB_ITER = CONST_NB_ITER;
 size_t M = WG_MULT0*J_CL_DEVICE_CONST_WORK_GROUP_SIZE0+JACOBI_DELTA;
-size_t K = WG_MULT1*J_CL_DEVICE_CONST_WORK_GROUP_SIZE1+JACOBI_DELTA;
+size_t N = WG_MULT1*J_CL_DEVICE_CONST_WORK_GROUP_SIZE1+JACOBI_DELTA;
 size_t J_CL_DEVICE_MAX_WORK_GROUP_SIZE0 = J_CL_DEVICE_CONST_WORK_GROUP_SIZE0;
 size_t J_CL_DEVICE_MAX_WORK_GROUP_SIZE1 = J_CL_DEVICE_CONST_WORK_GROUP_SIZE1;
 
@@ -258,7 +258,7 @@ void read_args(int argc, char **argv)
     try {
       NB_ITER = lexical_cast<size_t>(argv[1]);
       M = lexical_cast<size_t>(argv[2]);
-      K = lexical_cast<size_t>(argv[3]);
+      N = lexical_cast<size_t>(argv[3]);
     }
     catch(bad_lexical_cast &) {
       std::cout << "Bad number format." << std::endl;
@@ -299,7 +299,7 @@ void read_args(int argc, char **argv)
 
   std::cout << "Iterations  : " << NB_ITER << std::endl;
   std::cout << "Elements[0] : " << M << std::endl;
-  std::cout << "Elements[1] : " << K << std::endl;
+  std::cout << "Elements[1] : " << N << std::endl;
   std::cout << "Tile[0]     : " << J_CL_DEVICE_MAX_WORK_GROUP_SIZE0 << std::endl;
   std::cout << "Tile[1]     : " << J_CL_DEVICE_MAX_WORK_GROUP_SIZE1 << std::endl;
   std::cout << "Vec_size    : " << VEC_CONST_SIZE << std::endl;
@@ -323,8 +323,8 @@ void print_host2D(float * tab)
 {
     for (size_t i = 0; i < M; ++i)
     {
-        for(size_t j = 0; j < K; ++j)
-            std::cout << tab[i*K+j] << " " ;
+        for(size_t j = 0; j < N; ++j)
+            std::cout << tab[i*N+j] << " " ;
 
         std::cout << std::endl;
     }
@@ -332,7 +332,7 @@ void print_host2D(float * tab)
 
 void print_buffer2D(cl::sycl::accessor<float, 2, cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer> bufferAccessor) {
   for (size_t i = 0; i < M; ++i){
-    for(size_t j = 0; j < K; ++j){
+    for(size_t j = 0; j < N; ++j){
       std::cout << bufferAccessor[i][j] << " " ;
     }
     std::cout << std::endl;
@@ -352,8 +352,8 @@ void compute_jacobi2D(std::vector<float>& a_test,
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-            for (int j = 1; j < K - 1; ++j) {
-                b_test[i*K + j] = MULT_COEF * (a_test[i*K + j] + a_test[i*K + (j - 1)] + a_test[i*K + (1 + j)] + a_test[(1 + i)*K + j] + a_test[(i - 1)*K + j]);
+            for (int j = 1; j < N - 1; ++j) {
+                b_test[i*N + j] = MULT_COEF * (a_test[i*N + j] + a_test[i*N + (j - 1)] + a_test[i*N + (1 + j)] + a_test[(1 + i)*N + j] + a_test[(i - 1)*N + j]);
             }
         }
 
@@ -363,8 +363,8 @@ void compute_jacobi2D(std::vector<float>& a_test,
         being_op = counters::clock_type::now();
 
         for (int i = 1; i < M - 1; ++i) {
-            for (int j = 1; j < K - 1; ++j) {
-                a_test[i*K + j] = b_test[i*K + j];
+            for (int j = 1; j < N - 1; ++j) {
+                a_test[i*N + j] = b_test[i*N + j];
             }
         }
 
@@ -388,9 +388,9 @@ void ute_and_are(std::vector<float>& a_test,
   // compare with cpu result
   std::cout << "Result:" << std::endl;
   for(size_t i = 0; i < M; ++i){
-    for(size_t j = 0; j < K; ++j){
+    for(size_t j = 0; j < N; ++j){
       // Compare the result to the analytic value
-      float err = ABS((C[i][j] - a_test[i*K+j]) / a_test[i*K+j]);
+      float err = ABS((C[i][j] - a_test[i*N+j]) / a_test[i*N+j]);
       if ( err > ERR_MAX) {
         std::cout << "Wrong value " << C[i][j] << " on element "
                   << i << ' ' << j << " (error : " << err << ")" << std::endl;

--- a/tests/jacobi/include/helpers-jacobi.hpp
+++ b/tests/jacobi/include/helpers-jacobi.hpp
@@ -77,7 +77,7 @@ int es = PAPI_NULL; //event set
 
 size_t NB_ITER = CONST_NB_ITER;
 size_t M = WG_MULT0*J_CL_DEVICE_CONST_WORK_GROUP_SIZE0+JACOBI_DELTA;
-size_t N = WG_MULT1*J_CL_DEVICE_CONST_WORK_GROUP_SIZE1+JACOBI_DELTA;
+size_t K = WG_MULT1*J_CL_DEVICE_CONST_WORK_GROUP_SIZE1+JACOBI_DELTA;
 size_t J_CL_DEVICE_MAX_WORK_GROUP_SIZE0 = J_CL_DEVICE_CONST_WORK_GROUP_SIZE0;
 size_t J_CL_DEVICE_MAX_WORK_GROUP_SIZE1 = J_CL_DEVICE_CONST_WORK_GROUP_SIZE1;
 
@@ -258,7 +258,7 @@ void read_args(int argc, char **argv)
     try {
       NB_ITER = lexical_cast<size_t>(argv[1]);
       M = lexical_cast<size_t>(argv[2]);
-      N = lexical_cast<size_t>(argv[3]);
+      K = lexical_cast<size_t>(argv[3]);
     }
     catch(bad_lexical_cast &) {
       std::cout << "Bad number format." << std::endl;
@@ -299,7 +299,7 @@ void read_args(int argc, char **argv)
 
   std::cout << "Iterations  : " << NB_ITER << std::endl;
   std::cout << "Elements[0] : " << M << std::endl;
-  std::cout << "Elements[1] : " << N << std::endl;
+  std::cout << "Elements[1] : " << K << std::endl;
   std::cout << "Tile[0]     : " << J_CL_DEVICE_MAX_WORK_GROUP_SIZE0 << std::endl;
   std::cout << "Tile[1]     : " << J_CL_DEVICE_MAX_WORK_GROUP_SIZE1 << std::endl;
   std::cout << "Vec_size    : " << VEC_CONST_SIZE << std::endl;
@@ -323,8 +323,8 @@ void print_host2D(float * tab)
 {
     for (size_t i = 0; i < M; ++i)
     {
-        for(size_t j = 0; j < N; ++j)
-            std::cout << tab[i*N+j] << " " ;
+        for(size_t j = 0; j < K; ++j)
+            std::cout << tab[i*K+j] << " " ;
 
         std::cout << std::endl;
     }
@@ -332,7 +332,7 @@ void print_host2D(float * tab)
 
 void print_buffer2D(cl::sycl::accessor<float, 2, cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer> bufferAccessor) {
   for (size_t i = 0; i < M; ++i){
-    for(size_t j = 0; j < N; ++j){
+    for(size_t j = 0; j < K; ++j){
       std::cout << bufferAccessor[i][j] << " " ;
     }
     std::cout << std::endl;
@@ -352,8 +352,8 @@ void compute_jacobi2D(std::vector<float>& a_test,
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-            for (int j = 1; j < N - 1; ++j) {
-                b_test[i*N + j] = MULT_COEF * (a_test[i*N + j] + a_test[i*N + (j - 1)] + a_test[i*N + (1 + j)] + a_test[(1 + i)*N + j] + a_test[(i - 1)*N + j]);
+            for (int j = 1; j < K - 1; ++j) {
+                b_test[i*K + j] = MULT_COEF * (a_test[i*K + j] + a_test[i*K + (j - 1)] + a_test[i*K + (1 + j)] + a_test[(1 + i)*K + j] + a_test[(i - 1)*K + j]);
             }
         }
 
@@ -363,8 +363,8 @@ void compute_jacobi2D(std::vector<float>& a_test,
         being_op = counters::clock_type::now();
 
         for (int i = 1; i < M - 1; ++i) {
-            for (int j = 1; j < N - 1; ++j) {
-                a_test[i*N + j] = b_test[i*N + j];
+            for (int j = 1; j < K - 1; ++j) {
+                a_test[i*K + j] = b_test[i*K + j];
             }
         }
 
@@ -388,9 +388,9 @@ void ute_and_are(std::vector<float>& a_test,
   // compare with cpu result
   std::cout << "Result:" << std::endl;
   for(size_t i = 0; i < M; ++i){
-    for(size_t j = 0; j < N; ++j){
+    for(size_t j = 0; j < K; ++j){
       // Compare the result to the analytic value
-      float err = ABS((C[i][j] - a_test[i*N+j]) / a_test[i*N+j]);
+      float err = ABS((C[i][j] - a_test[i*K+j]) / a_test[i*K+j]);
       if ( err > ERR_MAX) {
         std::cout << "Wrong value " << C[i][j] << " on element "
                   << i << ' ' << j << " (error : " << err << ")" << std::endl;

--- a/tests/jacobi/include/stencil-fxd.hpp
+++ b/tests/jacobi/include/stencil-fxd.hpp
@@ -284,36 +284,36 @@ public:
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1, class C2>
-inline output_stencil_fxd2D<T, B, f, stencil_fxd2D<C1, C2, T>> operator<< (output_2D<T, B, f> out, stencil_fxd2D<C1, C2, T> in) {
+inline output_stencil_fxd2D<T, B, f, stencil_fxd2D<C1, C2, T>> operator<< (output_2D<T, B, f> /*out*/, stencil_fxd2D<C1, C2, T> in) {
   return output_stencil_fxd2D<T, B, f, stencil_fxd2D<C1, C2, T>> {in};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1>
-inline output_stencil_fxd2D<T, B, f, stencil_fxd2D_bis<C1, T>> operator<< (output_2D<T, B, f> out, stencil_fxd2D_bis<C1, T> in) {
+inline output_stencil_fxd2D<T, B, f, stencil_fxd2D_bis<C1, T>> operator<< (output_2D<T, B, f> /*out*/, stencil_fxd2D_bis<C1, T> in) {
   return output_stencil_fxd2D<T, B, f, stencil_fxd2D_bis<C1, T>> {in};
 }
 
 
 
 template <typename T, class C1, class C2, cl::sycl::buffer<T,2> *aB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>)>
-inline stencil_input_fxd2D<T, stencil_fxd2D<C1, C2, T>, aB, a_f> operator<< (stencil_fxd2D<C1, C2, T> out, input_fxd2D<T, aB, a_f> in) {
+inline stencil_input_fxd2D<T, stencil_fxd2D<C1, C2, T>, aB, a_f> operator<< (stencil_fxd2D<C1, C2, T> out, input_fxd2D<T, aB, a_f> /*in*/) {
   return stencil_input_fxd2D<T, stencil_fxd2D<C1, C2, T>, aB, a_f> {out};
 }
 
 template <typename T, class C1, cl::sycl::buffer<T,2> *aB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>)>
-inline stencil_input_fxd2D<T, stencil_fxd2D_bis<C1, T>, aB, a_f> operator<< (stencil_fxd2D_bis<C1, T> out, input_fxd2D<T, aB, a_f> in) {
+inline stencil_input_fxd2D<T, stencil_fxd2D_bis<C1, T>, aB, a_f> operator<< (stencil_fxd2D_bis<C1, T> out, input_fxd2D<T, aB, a_f> /*in*/) {
   return stencil_input_fxd2D<T, stencil_fxd2D_bis<C1, T>, aB, a_f> {out};
 }
 
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>)>
-inline operation_fxd2D<T, B, f, st, aB, a_f> operator<< (output_stencil_fxd2D<T, B, f, st> out, input_fxd2D<T, aB, a_f> in) {
+inline operation_fxd2D<T, B, f, st, aB, a_f> operator<< (output_stencil_fxd2D<T, B, f, st> out, input_fxd2D<T, aB, a_f> /*in*/) {
   return operation_fxd2D<T, B, f, st, aB, a_f> {out.stencil};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>)>
-inline operation_fxd2D<T, B, f, st, aB, a_f> operator<< (output_2D<T, B, f> out, stencil_input_fxd2D<T, st, aB, a_f> in) {
+inline operation_fxd2D<T, B, f, st, aB, a_f> operator<< (output_2D<T, B, f> /*out*/, stencil_input_fxd2D<T, st, aB, a_f> in) {
   return operation_fxd2D<T, B, f, st, aB, a_f> {in.stencil};
 }
 

--- a/tests/jacobi/include/stencil-fxd.hpp
+++ b/tests/jacobi/include/stencil-fxd.hpp
@@ -151,8 +151,8 @@ public:
   cl::sycl::range<2> range;
   cl::sycl::nd_range<2> nd_range = {cl::sycl::range<2> {}, cl::sycl::range<2> {}, cl::sycl::id<2> {}};
 
-  int global_max0;
-  int global_max1;
+  size_t global_max0;
+  size_t global_max1;
 
   const st stencil;
 
@@ -161,8 +161,8 @@ public:
     cl::sycl::range<2> rg2 = B->get_range();
     assert(rg1 == rg2); //seems a bad idea, indeed ! we will not do that ...
     range = rg1-d;
-    int r0 = range.get(0);
-    int r1 = range.get(1);
+    size_t r0 = range.get(0);
+    size_t r1 = range.get(1);
     global_max0 = r0;
     global_max1 = r1;
     if (r0 % li2D.nbi_wg0 != 0) {
@@ -177,21 +177,21 @@ public:
   }
 
   inline void eval(cl::sycl::id<2> id, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write> out, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in) {
-    int i = id.get(0) + of0;
-    int j = id.get(1) + of1;
-    f(i, j, out) = stencil.template eval<a_f>(in, i, j);
+    size_t i = id.get(0) + of0;
+    size_t j = id.get(1) + of1;
+    f((int)i, (int)j, out) = stencil.template eval<a_f>(in, (int)i, (int)j);
   }
 
   inline void eval_local(cl::sycl::nd_item<2> it, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write> out, T *local_tab, int glob_max0, int glob_max1) {
-    int i = it.get_global().get(0);
-    int j = it.get_global().get(1);
+    size_t i = it.get_global().get(0);
+    size_t j = it.get_global().get(1);
     if (i >= glob_max0 || j >= glob_max1)
       return;
     i += of0;
     j += of1;
-    int i_local = it.get_local().get(0) - st::min_ind0;
-    int j_local = it.get_local().get(1) - st::min_ind1;
-    f(i, j, out) = stencil.template eval_local<local_dim1>(local_tab, i_local, j_local);
+    size_t i_local = it.get_local().get(0) - st::min_ind0;
+    size_t j_local = it.get_local().get(1) - st::min_ind1;
+    f((int)i, (int)j, out) = stencil.template eval_local<local_dim1>(local_tab, (int)i_local, (int)j_local);
   }
 
   inline void store_local(T * local_tab, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in, cl::sycl::nd_item<2> it, cl::sycl::group<2> gr, int glob_max0, int glob_max1) {
@@ -199,32 +199,32 @@ public:
     cl::sycl::id<2> g_ind = gr.get(); //it.get_group_id(); error because ambiguous / operator redefinition 
     cl::sycl::id<2> l_ind = it.get_local();
 
-    int l_range0 = l_range.get(0);
-    int l_range1 = l_range.get(1);
-    int l_ind0 = l_ind.get(0);
-    int l_ind1 = l_ind.get(1);
-    int gr_ind0 = g_ind.get(0);
-    int gr_ind1 = g_ind.get(1);
+    size_t l_range0 = l_range.get(0);
+    size_t l_range1 = l_range.get(1);
+    size_t l_ind0 = l_ind.get(0);
+    size_t l_ind1 = l_ind.get(1);
+    size_t gr_ind0 = g_ind.get(0);
+    size_t gr_ind1 = g_ind.get(1);
 
-    int block_dim0 = local_dim0 / l_range0;
-    int block_dim1 = local_dim1 / l_range1;
-    int total_block_dim0 = block_dim0;
-    int total_block_dim1 = block_dim1;
+    size_t block_dim0 = local_dim0 / l_range0;
+    size_t block_dim1 = local_dim1 / l_range1;
+    size_t total_block_dim0 = block_dim0;
+    size_t total_block_dim1 = block_dim1;
     if (l_ind0 == l_range0 - 1)
       total_block_dim0 += local_dim0 % l_range0;
     if (l_ind1 == l_range1 - 1)
       total_block_dim1 += local_dim1 % l_range1;
 
-    int local_ind0 = l_ind0 * block_dim0;
-    int local_ind1 = l_ind1 * block_dim1;
-    int global_ind0 = gr_ind0 * l_range0 + local_ind0 + of0 + st::min_ind0;
-    int global_ind1 = gr_ind1 * l_range1 + local_ind1 + of1 + st::min_ind1;
+    size_t local_ind0 = l_ind0 * block_dim0;
+    size_t local_ind1 = l_ind1 * block_dim1;
+    size_t global_ind0 = gr_ind0 * l_range0 + local_ind0 + of0 + st::min_ind0;
+    size_t global_ind1 = gr_ind1 * l_range1 + local_ind1 + of1 + st::min_ind1;
 
     for (int i = 0; i < total_block_dim0; ++i){
       int j;
       for (j = 0; j < total_block_dim1; ++j){
         if (global_ind0 < glob_max0 && global_ind1 < glob_max1)
-          local_tab[local_ind0 * local_dim1 + local_ind1] = a_f(global_ind0, global_ind1, in);
+          local_tab[local_ind0 * local_dim1 + local_ind1] = a_f((int)global_ind0, (int)global_ind1, in);
         local_ind1++;
         global_ind1++;
       }
@@ -257,13 +257,13 @@ public:
                 /* group shoudn't be needed, neither global max*/
                 /* static function needed for st use a priori, but static not compatible
                    with dynamic filed as global_max */
-                store_local(local, _aB, it, group, global_max0+d0, global_max1+d1); 
+                store_local(local, _aB, it, group, static_cast<int>(global_max0+d0), static_cast<int>(global_max1+d1));
               });
             //synchro
             cl::sycl::parallel_for_work_item(group, [=](cl::sycl::nd_item<2> it){
                 //computing
                 /*operation_fxd2D<T, B, f, st, aB, bB, a_f, b_f>::*/
-                eval_local(it, _B, local, global_max0, global_max1);
+                eval_local(it, _B, local, static_cast<int>(global_max0), static_cast<int>(global_max1));
               });
             delete [] local;
           });

--- a/tests/jacobi/include/stencil-gen-var.hpp
+++ b/tests/jacobi/include/stencil-gen-var.hpp
@@ -130,16 +130,16 @@ public:
   cl::sycl::range<2> range;
   cl::sycl::nd_range<2> nd_range = {cl::sycl::range<2> {}, cl::sycl::range<2> {}, cl::sycl::id<2> {}};
 
-  int global_max0;
-  int global_max1;
+  size_t global_max0;
+  size_t global_max1;
 
   operation_var2D() {
     cl::sycl::range<2> rg1 = aB->get_range();
     cl::sycl::range<2> rg2 = B->get_range();
     assert(rg1 == rg2); //seems a bad idea, indeed ! we will not do that ...
     range = rg1-d;
-    int r0 = range.get(0);
-    int r1 = range.get(1);
+    size_t r0 = range.get(0);
+    size_t r1 = range.get(1);
     global_max0 = r0;
     global_max1 = r1;
     if (r0 % li2D.nbi_wg0 != 0) {
@@ -154,22 +154,22 @@ public:
   }
 
   static inline void eval(cl::sycl::id<2> id, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write> out, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read> coef) {
-    int i = id.get(0) + of0;
-    int j = id.get(1) + of1;
-    f(i, j, out) = st::template eval<T, a_f, b_f, c_f, r_f>(in, coef, i, j);
+    size_t i = id.get(0) + of0;
+    size_t j = id.get(1) + of1;
+    f((int)i, (int)j, out) = st::template eval<T, a_f, b_f, c_f, r_f>(in, coef, (int)i, (int)j);
   }
 
   // Not really static because of the use of global_max (which is passed by args)
   static inline void eval_local(cl::sycl::nd_item<2> it, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write> out, T *local_tab, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read> coef, int glob_max0, int glob_max1) {
-    int i = it.get_global().get(0);
-    int j = it.get_global().get(1);
+    size_t i = it.get_global().get(0);
+    size_t j = it.get_global().get(1);
     if (i >= glob_max0 || j >= glob_max1)
       return;
     i += of0;
     j += of1;
-    int i_local = it.get_local().get(0) - st::min_ind0;
-    int j_local = it.get_local().get(1) - st::min_ind1;
-    f(i, j, out) = st::template eval_local<T, local_dim1, b_f, c_f, r_f>(local_tab, coef, i, j, i_local, j_local);
+    size_t i_local = it.get_local().get(0) - st::min_ind0;
+    size_t j_local = it.get_local().get(1) - st::min_ind1;
+    f((int)i, (int)j, out) = st::template eval_local<T, local_dim1, b_f, c_f, r_f>(local_tab, coef, (int)i, (int)j, (int)i_local, (int)j_local);
   }
 
   // Not really static because of the use of global_max (which is passed by args)
@@ -178,32 +178,32 @@ public:
     cl::sycl::id<2> g_ind = gr.get(); //it.get_group_id(); error because ambiguous / operator redefinition 
     cl::sycl::id<2> l_ind = it.get_local();
 
-    int l_range0 = l_range.get(0);
-    int l_range1 = l_range.get(1);
-    int l_ind0 = l_ind.get(0);
-    int l_ind1 = l_ind.get(1);
-    int gr_ind0 = g_ind.get(0);
-    int gr_ind1 = g_ind.get(1);
+    size_t l_range0 = l_range.get(0);
+    size_t l_range1 = l_range.get(1);
+    size_t l_ind0 = l_ind.get(0);
+    size_t l_ind1 = l_ind.get(1);
+    size_t gr_ind0 = g_ind.get(0);
+    size_t gr_ind1 = g_ind.get(1);
 
-    int block_dim0 = local_dim0 / l_range0;
-    int block_dim1 = local_dim1 / l_range1;
-    int total_block_dim0 = block_dim0;
-    int total_block_dim1 = block_dim1;
+    size_t block_dim0 = local_dim0 / l_range0;
+    size_t block_dim1 = local_dim1 / l_range1;
+    size_t total_block_dim0 = block_dim0;
+    size_t total_block_dim1 = block_dim1;
     if (l_ind0 == l_range0 - 1)
       total_block_dim0 += local_dim0 % l_range0;
     if (l_ind1 == l_range1 - 1)
       total_block_dim1 += local_dim1 % l_range1;
 
-    int local_ind0 = l_ind0 * block_dim0;
-    int local_ind1 = l_ind1 * block_dim1;
-    int global_ind0 = gr_ind0 * l_range0 + local_ind0 + of0 + st::min_ind0;
-    int global_ind1 = gr_ind1 * l_range1 + local_ind1 + of1 + st::min_ind1;
+    size_t local_ind0 = l_ind0 * block_dim0;
+    size_t local_ind1 = l_ind1 * block_dim1;
+    size_t global_ind0 = gr_ind0 * l_range0 + local_ind0 + of0 + st::min_ind0;
+    size_t global_ind1 = gr_ind1 * l_range1 + local_ind1 + of1 + st::min_ind1;
 
     for (int i = 0; i < total_block_dim0; ++i){
       int j;
       for (j = 0; j < total_block_dim1; ++j){
         if (global_ind0 < glob_max0 && global_ind1 < glob_max1)
-          local_tab[local_ind0 * local_dim1 + local_ind1] = a_f(global_ind0, global_ind1, in);
+          local_tab[local_ind0 * local_dim1 + local_ind1] = a_f((int)global_ind0, (int)global_ind1, in);
         local_ind1++;
         global_ind1++;
       }
@@ -238,13 +238,13 @@ public:
                 /* group shoudn't be needed, neither global max*/
                 /* static function needed for st use a priori, but static not compatible
                    with dynamic filed as global_max */
-                store_local(local, _aB, it, group, global_max0+d0, global_max1+d1); 
+                store_local(local, _aB, it, group, static_cast<int>(global_max0+d0), static_cast<int>(global_max1+d1));
               });
             //synchro
             cl::sycl::parallel_for_work_item(group, [=](cl::sycl::nd_item<2> it){
                 //computing
                 /*operation_var2D<T, B, f, st, aB, bB, a_f, b_f>::*/
-                eval_local(it, _B, local, _bB, global_max0, global_max1);
+                eval_local(it, _B, local, _bB, static_cast<int>(global_max0), static_cast<int>(global_max1));
               });
             delete [] local;
           });

--- a/tests/jacobi/include/stencil-gen-var.hpp
+++ b/tests/jacobi/include/stencil-gen-var.hpp
@@ -73,22 +73,22 @@ public:
 };
 
 template <int i, int j, int k, int l>
-inline stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> operator+ (coef_var2D<i, j> coef0, coef_var2D<k, l> coef1) {
+inline stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> operator+ (coef_var2D<i, j> /*coef0*/, coef_var2D<k, l> /*coef1*/) {
   return stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> {};
 }
 
 template <int k, int l, class C1, class C2>
-inline stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> operator+ (stencil_var2D<C1, C2> st0, coef_var2D<k, l> coef1) {
+inline stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> operator+ (stencil_var2D<C1, C2> /*st0*/, coef_var2D<k, l> /*coef1*/) {
   return stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> {};
 }
 
 template <int k, int l, class C1, class C2>
-inline stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> operator+ (coef_var2D<k, l> coef0, stencil_var2D<C1, C2> st1) {
+inline stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> operator+ (coef_var2D<k, l> /*coef0*/, stencil_var2D<C1, C2> /*st1*/) {
   return stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> {};
 }
 
 template <class C1, class C2, class C3, class C4>
-inline stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> operator+ (stencil_var2D<C1, C2> st0, stencil_var2D<C3, C4> st1) {
+inline stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> operator+ (stencil_var2D<C1, C2> /*st0*/, stencil_var2D<C3, C4> /*st1*/) {
   return stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> {};
 }
 
@@ -261,36 +261,36 @@ class output_stencil_var2D {};
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1, class C2>
-inline output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> operator<< (output_2D<T, B, f> out, stencil_var2D<C1, C2> in) {
+inline output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> operator<< (output_2D<T, B, f> /*out*/, stencil_var2D<C1, C2> /*in*/) {
   return output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> {};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1>
-inline output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> operator<< (output_2D<T, B, f> out, stencil_var2D_bis<C1> in) {
+inline output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> operator<< (output_2D<T, B, f> /*out*/, stencil_var2D_bis<C1> /*in*/) {
   return output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> {};
 }
 
 
 
 template <typename T, class C1, class C2, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>), T (*c_f) (T, T) = coef_times<T>, T (*r_f) (T, T) = coef_plus<T>>
-  inline stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f, r_f> operator<< (stencil_var2D<C1, C2> out, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> in) {
+  inline stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f, r_f> operator<< (stencil_var2D<C1, C2> /*out*/, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> /*in*/) {
   return stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f, r_f> {};
 }
 
 template <typename T, class C1, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>), T (*c_f) (T, T) = coef_times<T>, T (*r_f) (T, T) = coef_plus<T>>
-  inline stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f, c_f, r_f> operator<< (stencil_var2D_bis<C1> out, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> in) {
+  inline stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f, c_f, r_f> operator<< (stencil_var2D_bis<C1> /*out*/, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> /*in*/) {
   return stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f, c_f, r_f> {};
 }
 
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>), T (*c_f) (T, T) = coef_times<T>, T (*r_f) (T, T) = coef_plus<T>>
-  inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> operator<< (output_stencil_var2D<T, B, f, st> out, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> in) {
+  inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> operator<< (output_stencil_var2D<T, B, f, st> /*out*/, input_var2D<T, aB, bB, a_f, b_f, c_f, r_f> /*in*/) {
   return operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> {};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>), T (*c_f) (T, T) = coef_times<T>, T (*r_f) (T, T) = coef_plus<T>>
-  inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> operator<< (output_2D<T, B, f> out, stencil_input_var2D<T, st, aB, bB, a_f, b_f, c_f, r_f> in) {
+  inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> operator<< (output_2D<T, B, f> /*out*/, stencil_input_var2D<T, st, aB, bB, a_f, b_f, c_f, r_f> /*in*/) {
   return operation_var2D<T, B, f, st, aB, bB, a_f, b_f, c_f, r_f> {};
 }
 

--- a/tests/jacobi/include/stencil-var.hpp
+++ b/tests/jacobi/include/stencil-var.hpp
@@ -73,22 +73,22 @@ public:
 };
 
 template <int i, int j, int k, int l>
-inline stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> operator+ (coef_var2D<i, j> coef0, coef_var2D<k, l> coef1) {
+inline stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> operator+ (coef_var2D<i, j> /*coef0*/, coef_var2D<k, l> /*coef1*/) {
   return stencil_var2D<coef_var2D<i, j>, coef_var2D<k, l>> {};
 }
 
 template <int k, int l, class C1, class C2>
-inline stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> operator+ (stencil_var2D<C1, C2> st0, coef_var2D<k, l> coef1) {
+inline stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> operator+ (stencil_var2D<C1, C2> /*st0*/, coef_var2D<k, l> /*coef1*/) {
   return stencil_var2D<stencil_var2D<C1, C2>, coef_var2D<k, l>> {};
 }
 
 template <int k, int l, class C1, class C2>
-inline stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> operator+ (coef_var2D<k, l> coef0, stencil_var2D<C1, C2> st1) {
+inline stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> operator+ (coef_var2D<k, l> /*coef0*/, stencil_var2D<C1, C2> /*st1*/) {
   return stencil_var2D<coef_var2D<k, l>, stencil_var2D<C1, C2>> {};
 }
 
 template <class C1, class C2, class C3, class C4>
-inline stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> operator+ (stencil_var2D<C1, C2> st0, stencil_var2D<C3, C4> st1) {
+inline stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> operator+ (stencil_var2D<C1, C2> /*st0*/, stencil_var2D<C3, C4> /*st1*/) {
   return stencil_var2D<stencil_var2D<C1, C2>, stencil_var2D<C3, C4>> {};
 }
 
@@ -262,36 +262,36 @@ class output_stencil_var2D {};
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1, class C2>
-inline output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> operator<< (output_2D<T, B, f> out, stencil_var2D<C1, C2> in) {
+inline output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> operator<< (output_2D<T, B, f> /*out*/, stencil_var2D<C1, C2> /*in*/) {
   return output_stencil_var2D<T, B, f, stencil_var2D<C1, C2>> {};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class C1>
-inline output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> operator<< (output_2D<T, B, f> out, stencil_var2D_bis<C1> in) {
+inline output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> operator<< (output_2D<T, B, f> /*out*/, stencil_var2D_bis<C1> /*in*/) {
   return output_stencil_var2D<T, B, f, stencil_var2D_bis<C1>> {};
 }
 
 
 
 template <typename T, class C1, class C2, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>)>
-inline stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f> operator<< (stencil_var2D<C1, C2> out, input_var2D<T, aB, bB, a_f, b_f> in) {
+inline stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f> operator<< (stencil_var2D<C1, C2> /*out*/, input_var2D<T, aB, bB, a_f, b_f> /*in*/) {
   return stencil_input_var2D<T, stencil_var2D<C1, C2>, aB, bB, a_f, b_f> {};
 }
 
 template <typename T, class C1, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>)>
-inline stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f> operator<< (stencil_var2D_bis<C1> out, input_var2D<T, aB, bB, a_f, b_f> in) {
+inline stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f> operator<< (stencil_var2D_bis<C1> /*out*/, input_var2D<T, aB, bB, a_f, b_f> /*in*/) {
   return stencil_input_var2D<T, stencil_var2D_bis<C1>, aB, bB, a_f, b_f> {};
 }
 
 
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>)>
-inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f> operator<< (output_stencil_var2D<T, B, f, st> out, input_var2D<T, aB, bB, a_f, b_f> in) {
+inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f> operator<< (output_stencil_var2D<T, B, f, st> /*out*/, input_var2D<T, aB, bB, a_f, b_f> /*in*/) {
   return operation_var2D<T, B, f, st, aB, bB, a_f, b_f> {};
 }
 
 template <typename T, cl::sycl::buffer<T,2> *B, T& (*f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::write>), class st, cl::sycl::buffer<T,2> *aB, cl::sycl::buffer<T,1> *bB, T (*a_f) (int,int, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read>), T (*b_f) (int,int,int,int, cl::sycl::accessor<T, 1, cl::sycl::access::mode::read>)>
-inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f> operator<< (output_2D<T, B, f> out, stencil_input_var2D<T, st, aB, bB, a_f, b_f> in) {
+inline operation_var2D<T, B, f, st, aB, bB, a_f, b_f> operator<< (output_2D<T, B, f> /*out*/, stencil_input_var2D<T, st, aB, bB, a_f, b_f> /*in*/) {
   return operation_var2D<T, B, f, st, aB, bB, a_f, b_f> {};
 }
 

--- a/tests/jacobi/jacobi2d-st-cplx-var.cpp
+++ b/tests/jacobi/jacobi2d-st-cplx-var.cpp
@@ -31,8 +31,8 @@ Complex coeff(0.2f,0.0f);
 
 inline Complex& fdl_out(int a,int b, cl::sycl::accessor<Complex, 2, cl::sycl::access::mode::write> acc) {return acc[a][b];}
 inline Complex  fdl_in(int a,int b, cl::sycl::accessor<Complex, 2, cl::sycl::access::mode::read>  acc) {return acc[a][b];}
-inline Complex  fac(int a,int b, int c, int d, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return coeff*acc[0];}
-inline Complex  fac_id(int a,int b, int c, int d, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
+inline Complex  fac(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return coeff*acc[0];}
+inline Complex  fac_id(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
 
 // static declaration to use pointers
 cl::sycl::buffer<Complex,2> ioBuffer;

--- a/tests/jacobi/jacobi2d-st-cplx-var.cpp
+++ b/tests/jacobi/jacobi2d-st-cplx-var.cpp
@@ -26,12 +26,12 @@ Complex operator*(const Complex& a, const Complex& b) {
 }
 
 
-Complex coef(0.2f,0.0f);
+Complex coeff(0.2f,0.0f);
 
 
 inline Complex& fdl_out(int a,int b, cl::sycl::accessor<Complex, 2, cl::sycl::access::mode::write> acc) {return acc[a][b];}
 inline Complex  fdl_in(int a,int b, cl::sycl::accessor<Complex, 2, cl::sycl::access::mode::read>  acc) {return acc[a][b];}
-inline Complex  fac(int a,int b, int c, int d, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return coef*acc[0];}
+inline Complex  fac(int a,int b, int c, int d, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return coeff*acc[0];}
 inline Complex  fac_id(int a,int b, int c, int d, cl::sycl::accessor<Complex, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
 
 // static declaration to use pointers
@@ -46,14 +46,14 @@ int main(int argc, char **argv) {
 
   // declarations
   Complex ioB(1.0, 1.0);
-  ioBuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, N});
-  ioABuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, N}); 
+  ioBuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, K});
+  ioABuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, K}); 
   ioBBuffer = cl::sycl::buffer<Complex,1>(&ioB, cl::sycl::range<1> {1}); 
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < N; ++j){
-      float tmp = (float) (i*(j+2) + 10) / N;
+    for (size_t j = 0; j < K; ++j){
+      float tmp = (float) (i*(j+2) + 10) / K;
       Complex value(tmp, tmp);
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;

--- a/tests/jacobi/jacobi2d-st-cplx-var.cpp
+++ b/tests/jacobi/jacobi2d-st-cplx-var.cpp
@@ -46,14 +46,14 @@ int main(int argc, char **argv) {
 
   // declarations
   Complex ioB(1.0, 1.0);
-  ioBuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, K});
-  ioABuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, K}); 
+  ioBuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, N});
+  ioABuffer = cl::sycl::buffer<Complex,2>(cl::sycl::range<2> {M, N}); 
   ioBBuffer = cl::sycl::buffer<Complex,1>(&ioB, cl::sycl::range<1> {1}); 
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < K; ++j){
-      float tmp = (float) (i*(j+2) + 10) / K;
+    for (size_t j = 0; j < N; ++j){
+      float tmp = (float) (i*(j+2) + 10) / N;
       Complex value(tmp, tmp);
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;

--- a/tests/jacobi/jacobi2d-st-fxd.cpp
+++ b/tests/jacobi/jacobi2d-st-fxd.cpp
@@ -17,23 +17,23 @@ int main(int argc, char **argv) {
   start_measure(timer);
 
   // Assign new buffers to the global buffers
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * K);
-  std::vector<float> b_test(M * K);
+  std::vector<float> a_test(M * N);
+  std::vector<float> b_test(M * N);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < K; ++j){
-      float value = ((float) i*(j+2) + 10) / K;
+    for (size_t j = 0; j < N; ++j){
+      float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*K+j] = value;
-      b_test[i*K+j] = value;
+      a_test[i*N+j] = value;
+      b_test[i*N+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-fxd.cpp
+++ b/tests/jacobi/jacobi2d-st-fxd.cpp
@@ -17,23 +17,23 @@ int main(int argc, char **argv) {
   start_measure(timer);
 
   // Assign new buffers to the global buffers
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * N);
-  std::vector<float> b_test(M * N);
+  std::vector<float> a_test(M * K);
+  std::vector<float> b_test(M * K);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < N; ++j){
-      float value = ((float) i*(j+2) + 10) / N;
+    for (size_t j = 0; j < K; ++j){
+      float value = ((float) i*(j+2) + 10) / K;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*N+j] = value;
-      b_test[i*N+j] = value;
+      a_test[i*K+j] = value;
+      b_test[i*K+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-gen-var.cpp
+++ b/tests/jacobi/jacobi2d-st-gen-var.cpp
@@ -11,8 +11,8 @@ inline float reduc_op(float el1, float el2) {return el1+el2;}
 // acces functions
 inline float& fdl_out(int a,int b, cl::sycl::accessor<float, 2, cl::sycl::access::mode::write> acc) {return acc[a][b];}
 inline float  fdl_in(int a,int b, cl::sycl::accessor<float, 2, cl::sycl::access::mode::read>  acc) {return acc[a][b];}
-inline float  fac(int a,int b, int c, int d, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return MULT_COEF*acc[0];}
-inline float  fac_id(int a,int b, int c, int d, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
+inline float  fac(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return MULT_COEF*acc[0];}
+inline float  fac_id(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
 
 // static declaration to use pointers
 cl::sycl::buffer<float,2> ioBuffer;

--- a/tests/jacobi/jacobi2d-st-gen-var.cpp
+++ b/tests/jacobi/jacobi2d-st-gen-var.cpp
@@ -27,24 +27,24 @@ int main(int argc, char **argv) {
   // declarations
   float tab_var = 1.0;
   float *ioB = &tab_var;
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K}); 
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N}); 
   ioBBuffer = cl::sycl::buffer<float,1>(ioB, cl::sycl::range<1> {1}); 
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * K);
-  std::vector<float> b_test(M * K);
+  std::vector<float> a_test(M * N);
+  std::vector<float> b_test(M * N);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < K; ++j){
-      float value = ((float) i*(j+2) + 10) / K;
+    for (size_t j = 0; j < N; ++j){
+      float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*K+j] = value;
-      b_test[i*K+j] = value;
+      a_test[i*N+j] = value;
+      b_test[i*N+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-gen-var.cpp
+++ b/tests/jacobi/jacobi2d-st-gen-var.cpp
@@ -27,24 +27,24 @@ int main(int argc, char **argv) {
   // declarations
   float tab_var = 1.0;
   float *ioB = &tab_var;
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N}); 
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K}); 
   ioBBuffer = cl::sycl::buffer<float,1>(ioB, cl::sycl::range<1> {1}); 
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * N);
-  std::vector<float> b_test(M * N);
+  std::vector<float> a_test(M * K);
+  std::vector<float> b_test(M * K);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < N; ++j){
-      float value = ((float) i*(j+2) + 10) / N;
+    for (size_t j = 0; j < K; ++j){
+      float value = ((float) i*(j+2) + 10) / K;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*N+j] = value;
-      b_test[i*N+j] = value;
+      a_test[i*K+j] = value;
+      b_test[i*K+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-var.cpp
+++ b/tests/jacobi/jacobi2d-st-var.cpp
@@ -22,24 +22,24 @@ int main(int argc, char **argv) {
   // declarations
   float tab_var = 1.0;
   float *ioB = &tab_var;
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K}); 
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N}); 
   ioBBuffer = cl::sycl::buffer<float,1>(ioB, cl::sycl::range<1> {1}); 
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * K);
-  std::vector<float> b_test(M * K);
+  std::vector<float> a_test(M * N);
+  std::vector<float> b_test(M * N);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < K; ++j){
-      float value = ((float) i*(j+2) + 10) / K;
+    for (size_t j = 0; j < N; ++j){
+      float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*K+j] = value;
-      b_test[i*K+j] = value;
+      a_test[i*N+j] = value;
+      b_test[i*N+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-var.cpp
+++ b/tests/jacobi/jacobi2d-st-var.cpp
@@ -22,24 +22,24 @@ int main(int argc, char **argv) {
   // declarations
   float tab_var = 1.0;
   float *ioB = &tab_var;
-  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N});
-  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, N}); 
+  ioBuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K});
+  ioABuffer = cl::sycl::buffer<float,2>(cl::sycl::range<2> {M, K}); 
   ioBBuffer = cl::sycl::buffer<float,1>(ioB, cl::sycl::range<1> {1}); 
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * N);
-  std::vector<float> b_test(M * N);
+  std::vector<float> a_test(M * K);
+  std::vector<float> b_test(M * K);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < N; ++j){
-      float value = ((float) i*(j+2) + 10) / N;
+    for (size_t j = 0; j < K; ++j){
+      float value = ((float) i*(j+2) + 10) / K;
       cl::sycl::id<2> id = {i, j};
       ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
       ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*N+j] = value;
-      b_test[i*N+j] = value;
+      a_test[i*K+j] = value;
+      b_test[i*K+j] = value;
 #endif
     }
   }

--- a/tests/jacobi/jacobi2d-st-var.cpp
+++ b/tests/jacobi/jacobi2d-st-var.cpp
@@ -6,8 +6,8 @@
 
 inline float& fdl_out(int a,int b, cl::sycl::accessor<float, 2, cl::sycl::access::mode::write> acc) {return acc[a][b];}
 inline float  fdl_in(int a,int b, cl::sycl::accessor<float, 2, cl::sycl::access::mode::read>  acc) {return acc[a][b];}
-inline float  fac(int a,int b, int c, int d, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return MULT_COEF*acc[0];}
-inline float  fac_id(int a,int b, int c, int d, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
+inline float  fac(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return MULT_COEF*acc[0];}
+inline float  fac_id(int /*a*/,int /*b*/, int /*c*/, int /*d*/, cl::sycl::accessor<float, 1, cl::sycl::access::mode::read>  acc) {return acc[0];}
 
 // static declaration to use pointers
 cl::sycl::buffer<float,2> ioBuffer;

--- a/tests/jacobi/jacobi2d-tile.cpp
+++ b/tests/jacobi/jacobi2d-tile.cpp
@@ -13,23 +13,23 @@ int main(int argc, char **argv) {
   start_measure(timer);
 
   // declarations
-  sycl::buffer<float,2> ioABuffer = cl::sycl::buffer<float,2>(sycl::range<2> {M, K});
-  sycl::buffer<float,2> ioBBuffer = sycl::buffer<float,2>(sycl::range<2> {M, K}); 
+  sycl::buffer<float,2> ioABuffer = cl::sycl::buffer<float,2>(sycl::range<2> {M, N});
+  sycl::buffer<float,2> ioBBuffer = sycl::buffer<float,2>(sycl::range<2> {M, N}); 
 #if DEBUG_STENCIL
-  std::vector<float> a_test(M * K);
-  std::vector<float> b_test(M * K);
+  std::vector<float> a_test(M * N);
+  std::vector<float> b_test(M * N);
 #endif
 
   // initialization
   for (size_t i = 0; i < M; ++i){
-    for (size_t j = 0; j < K; ++j){
-      float value = ((float) i*(j+2) + 10) / K;
+    for (size_t j = 0; j < N; ++j){
+      float value = ((float) i*(j+2) + 10) / N;
       sycl::id<2> id = {i, j};
       ioABuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
       ioBBuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-      a_test[i*K+j] = value;
-      b_test[i*K+j] = value;
+      a_test[i*N+j] = value;
+      b_test[i*N+j] = value;
 #endif
     }
   }
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
           sycl::accessor<float, 2, sycl::access::mode::write> b(ioBBuffer, cgh);
 
           cgh.parallel_for_work_group<class KernelCompute>(sycl::nd_range<2> {
-              sycl::range<2> {M-2, K-2},
+              sycl::range<2> {M-2, N-2},
                 sycl::range<2> {J_CL_DEVICE_MAX_WORK_GROUP_SIZE0, J_CL_DEVICE_MAX_WORK_GROUP_SIZE1}, 
                   sycl::id<2> {1, 1}},
             [=,&timer](sycl::group<2> group){
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
       myQueue.submit([&](sycl::handler &cgh) {
           sycl::accessor<float, 2, sycl::access::mode::write> a(ioABuffer, cgh);
           sycl::accessor<float, 2, sycl::access::mode::read>  b(ioBBuffer, cgh);
-          cgh.parallel_for<class KernelCopy>(sycl::range<2> {M-2, K-2},
+          cgh.parallel_for<class KernelCopy>(sycl::range<2> {M-2, N-2},
                                              sycl::id<2> {1, 1},
                                              [=] (sycl::item<2> it) {
                                                a[it] = MULT_COEF * b[it];

--- a/tests/jacobi/jacobi2d.cpp
+++ b/tests/jacobi/jacobi2d.cpp
@@ -19,26 +19,26 @@ int main(int argc, char **argv)
     start_measure(timer);
 
     // declarations
-    sycl::buffer<float, 2> ioABuffer = cl::sycl::buffer<float, 2>(sycl::range<2> {M, N});
-    sycl::buffer<float, 2> ioBBuffer = sycl::buffer<float, 2>(sycl::range<2> {M, N});
+    sycl::buffer<float, 2> ioABuffer = cl::sycl::buffer<float, 2>(sycl::range<2> {M, K});
+    sycl::buffer<float, 2> ioBBuffer = sycl::buffer<float, 2>(sycl::range<2> {M, K});
 
 #if DEBUG_STENCIL
-    std::vector<float> a_test(M * N);
-    std::vector<float> b_test(M * N);
+    std::vector<float> a_test(M * K);
+    std::vector<float> b_test(M * K);
 #endif
 
     // initialization
     for (size_t i = 0; i < M; ++i)
     {
-        for (size_t j = 0; j < N; ++j)
+        for (size_t j = 0; j < K; ++j)
         {
-            float value = ((float)i*(j + 2) + 10) / N;
+            float value = ((float)i*(j + 2) + 10) / K;
             sycl::id<2> id = { i, j };
             ioABuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
             ioBBuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
 #if DEBUG_STENCIL
-            a_test[i*N + j] = value;
-            b_test[i*N + j] = value;
+            a_test[i*K + j] = value;
+            b_test[i*K + j] = value;
 #endif
         }
     }
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
       myQueue.submit([&](sycl::handler &cgh) {
           sycl::accessor<float, 2, sycl::access::mode::read>  a(ioABuffer, cgh);
           sycl::accessor<float, 2, sycl::access::mode::write> b(ioBBuffer, cgh);
-          cgh.parallel_for<class KernelCompute>(sycl::range<2> {M-2, N-2},
+          cgh.parallel_for<class KernelCompute>(sycl::range<2> {M-2, K-2},
                                                 sycl::id<2> {1, 1},
                                                 [=] (sycl::item<2> it) {
                                  sycl::id<2> index = it.get();
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
       myQueue.submit([&](sycl::handler &cgh) {
           sycl::accessor<float, 2, sycl::access::mode::write> a(ioABuffer, cgh);
           sycl::accessor<float, 2, sycl::access::mode::read>  b(ioBBuffer, cgh);
-          cgh.parallel_for<class KernelCopy>(sycl::range<2> {M-2, N-2},
+          cgh.parallel_for<class KernelCopy>(sycl::range<2> {M-2, K-2},
                                              sycl::id<2> {1, 1},
                                              [=] (sycl::item<2> it) {
                                                a[it] = MULT_COEF * b[it];

--- a/tests/kernel/functor.cpp
+++ b/tests/kernel/functor.cpp
@@ -9,8 +9,6 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 30;
-
 // A kernel described as a functor for a parallel for
 class ParallelFor {
  using accessor_type = accessor<unsigned int,
@@ -67,6 +65,8 @@ public:
 
 
 int main() {
+  constexpr size_t N = 30;
+
   {
     queue q;
 

--- a/tests/kernel/functor.cpp
+++ b/tests/kernel/functor.cpp
@@ -86,7 +86,7 @@ int main() {
         cgh.single_task(SingleTask { 42, acc });
       });
     // Verify that b[0] == 42
-    VERIFY_BUFFER_VALUE(b, [](id<1> i) { return 42; });
+    VERIFY_BUFFER_VALUE(b, [](id<1>) { return 42; });
 
   }
   return 0;

--- a/tests/kernel/functor.cpp
+++ b/tests/kernel/functor.cpp
@@ -11,7 +11,7 @@ using namespace cl::sycl;
 
 // A kernel described as a functor for a parallel for
 class ParallelFor {
- using accessor_type = accessor<unsigned int,
+ using accessor_type = accessor<size_t,
                                 1,
                                 access::mode::write,
                                 access::target::global_buffer>;
@@ -29,7 +29,7 @@ public:
      Since it is to be used in a 1D parallel_for, it takes a item<1>
      or even an integer as a parameter
   */
-  void operator()(int index) {
+  void operator()(size_t index) {
     a[index] = index;
   }
 
@@ -70,7 +70,7 @@ int main() {
   {
     queue q;
 
-    buffer<unsigned int, 1> a { N };
+    buffer<size_t, 1> a { N };
     q.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);
         // Show that we can use a simple parallel_for with int, for example

--- a/tests/kernel/functor_item.cpp
+++ b/tests/kernel/functor_item.cpp
@@ -9,8 +9,6 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 30;
-
 // A kernel described as a functor for a parallel for
 class ParallelFor {
  using accessor_type = accessor<unsigned int,
@@ -67,6 +65,8 @@ public:
 
 
 int main() {
+  constexpr size_t N = 30;
+
   {
     queue q;
 

--- a/tests/kernel/functor_item.cpp
+++ b/tests/kernel/functor_item.cpp
@@ -11,7 +11,7 @@ using namespace cl::sycl;
 
 // A kernel described as a functor for a parallel for
 class ParallelFor {
- using accessor_type = accessor<unsigned int,
+ using accessor_type = accessor<size_t,
                                 1,
                                 access::mode::write,
                                 access::target::global_buffer>;
@@ -70,7 +70,7 @@ int main() {
   {
     queue q;
 
-    buffer<unsigned int, 1> a { range<1>{N} };
+    buffer<size_t, 1> a { range<1>{N} };
     q.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);
         cgh.parallel_for(range<1>{N}, ParallelFor { acc });

--- a/tests/kernel/functor_item.cpp
+++ b/tests/kernel/functor_item.cpp
@@ -84,7 +84,7 @@ int main() {
         cgh.single_task(SingleTask { 42, acc });
       });
     // Verify that b[0] == 42
-    VERIFY_BUFFER_VALUE(b, [](id<1> i) { return 42; });
+    VERIFY_BUFFER_VALUE(b, [](id<1>) { return 42; });
 
   }
   return 0;

--- a/tests/kernel/opencl_kernel.cpp
+++ b/tests/kernel/opencl_kernel.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel.cpp
+++ b/tests/kernel/opencl_kernel.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel_empty.cpp
+++ b/tests/kernel/opencl_kernel_empty.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel_empty.cpp
+++ b/tests/kernel/opencl_kernel_empty.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel_empty_set_args.cpp
+++ b/tests/kernel/opencl_kernel_empty_set_args.cpp
@@ -12,7 +12,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel_empty_set_args.cpp
+++ b/tests/kernel/opencl_kernel_empty_set_args.cpp
@@ -12,7 +12,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Construct an OpenCL program from the source string
   auto program = boost::compute::program::create_with_source(R"(
     __kernel void empty() {

--- a/tests/kernel/opencl_kernel_vector_add.cpp
+++ b/tests/kernel/opencl_kernel_vector_add.cpp
@@ -11,10 +11,10 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/kernel/opencl_kernel_vector_add.cpp
+++ b/tests/kernel/opencl_kernel_vector_add.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/kernel/opencl_kernel_vector_add.cpp
+++ b/tests/kernel/opencl_kernel_vector_add.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/kernel/opencl_kernel_vector_add_args.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args.cpp
@@ -11,10 +11,10 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/kernel/opencl_kernel_vector_add_args.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/kernel/opencl_kernel_vector_add_args.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/kernel/opencl_kernel_vector_add_args_42.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args_42.cpp
@@ -11,10 +11,10 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/kernel/opencl_kernel_vector_add_args_42.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args_42.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/kernel/opencl_kernel_vector_add_args_42.cpp
+++ b/tests/kernel/opencl_kernel_vector_add_args_42.cpp
@@ -11,7 +11,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 3;
   using Vector = float[N];
 

--- a/tests/math/math.cpp
+++ b/tests/math/math.cpp
@@ -15,7 +15,7 @@ using namespace cl::sycl;
 #define TRYSYCL_MATH_WRAPX3s(FUN, i) std::cout << FUN(i, i, i) << std::endl;
 #define TRYSYCL_MATH_WRAPX3ss(FUN, i) std::cout << FUN(i, i, i) << std::endl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr auto N = 100;
   for (auto k = 0; k < N; k++) {
     double i = k;

--- a/tests/math/math.cpp
+++ b/tests/math/math.cpp
@@ -15,7 +15,7 @@ using namespace cl::sycl;
 #define TRYSYCL_MATH_WRAPX3s(FUN, i) std::cout << FUN(i, i, i) << std::endl;
 #define TRYSYCL_MATH_WRAPX3ss(FUN, i) std::cout << FUN(i, i, i) << std::endl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr auto N = 100;
   for (auto k = 0; k < N; k++) {
     double i = k;

--- a/tests/math/opencl_type.cpp
+++ b/tests/math/opencl_type.cpp
@@ -10,7 +10,7 @@
 #include <boost/test/minimal.hpp>
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   cl::sycl::cl_float3 vec { 0, 1, 2 };
   std::cout << "x: "    << vec.x()
             << ", y: "  << vec.y()

--- a/tests/math/opencl_type.cpp
+++ b/tests/math/opencl_type.cpp
@@ -10,7 +10,7 @@
 #include <boost/test/minimal.hpp>
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   cl::sycl::cl_float3 vec { 0, 1, 2 };
   std::cout << "x: "    << vec.x()
             << ", y: "  << vec.y()

--- a/tests/multiple_compilation_units/parallel_for_other.C
+++ b/tests/multiple_compilation_units/parallel_for_other.C
@@ -9,10 +9,10 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 void other() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   float c[N];

--- a/tests/nd_item/nd_item.cpp
+++ b/tests/nd_item/nd_item.cpp
@@ -58,7 +58,7 @@ using namespace cl::sycl;
 
 #define DISPLAY_ELEMENTS(method)                                \
   do {                                                          \
-    for (size_t i = 0; i != decltype(ndi)::dimensionality; ++i) \
+    for (int i = 0; i != decltype(ndi)::dimensionality; ++i)    \
       std::cout << ndi.method(i) << ' ';                        \
     std::cout << std::endl;                                     \
   } while (0)

--- a/tests/nd_range/nd_range.cpp
+++ b/tests/nd_range/nd_range.cpp
@@ -23,7 +23,7 @@
 using namespace cl::sycl;
 
 // To test the inference of the range rank
-template<int N> void f(range<N> r) {
+template<int N> void f(range<N>) {
   std::cout << "Range of dims " << N << std::endl;
 }
 

--- a/tests/parallel_for/initializer_list.cpp
+++ b/tests/parallel_for/initializer_list.cpp
@@ -11,7 +11,7 @@ int main() {
   {
     queue myQueue;
 
-    buffer<unsigned int,1> a(N);
+    buffer<size_t,1> a(N);
 
     myQueue.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);
@@ -22,7 +22,7 @@ int main() {
       });
     VERIFY_BUFFER_VALUE(a, [](id<1> i) { return i[0]; });
 
-    buffer<unsigned int,2> b({ N, 3 });
+    buffer<size_t,2> b({ N, 3 });
 
     myQueue.submit([&](handler &cgh) {
         auto acc = b.get_access<access::mode::write>(cgh);

--- a/tests/parallel_for/initializer_list.cpp
+++ b/tests/parallel_for/initializer_list.cpp
@@ -5,9 +5,9 @@
 #include "test-helpers.hpp"
 using namespace cl::sycl;
 
-constexpr size_t N = 5;
-
 int main() {
+  constexpr size_t N = 5;
+
   {
     queue myQueue;
 

--- a/tests/parallel_for/integer.cpp
+++ b/tests/parallel_for/integer.cpp
@@ -12,7 +12,7 @@ int main() {
   {
     queue myQueue;
 
-    buffer<unsigned int,1> a(N);
+    buffer<int,1> a(N);
     myQueue.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);
         // Show that we can use a simple parallel_for with int, for example

--- a/tests/parallel_for/integer.cpp
+++ b/tests/parallel_for/integer.cpp
@@ -6,9 +6,9 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 30;
-
 int main() {
+  constexpr size_t N = 30;
+
   {
     queue myQueue;
 

--- a/tests/parallel_for/item.cpp
+++ b/tests/parallel_for/item.cpp
@@ -5,9 +5,9 @@
 #include "test-helpers.hpp"
 using namespace cl::sycl;
 
-constexpr size_t N = 5;
-
 int main() {
+  constexpr size_t N = 5;
+
   {
     queue myQueue;
 

--- a/tests/parallel_for/item.cpp
+++ b/tests/parallel_for/item.cpp
@@ -12,7 +12,7 @@ int main() {
     queue myQueue;
 
 
-    buffer<unsigned int,1> a(N);
+    buffer<size_t,1> a(N);
 
     myQueue.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);

--- a/tests/parallel_for/item_no_offset.cpp
+++ b/tests/parallel_for/item_no_offset.cpp
@@ -12,7 +12,7 @@ int main() {
   {
     queue myQueue;
 
-    buffer<unsigned int,1> a(range<1>{N});
+    buffer<size_t,1> a(range<1>{N});
     myQueue.submit([&](handler &cgh) {
         auto acc = a.get_access<access::mode::write>(cgh);
         cgh.parallel_for<class nothing>(range<1>{N}, [=] (item<1> index) {

--- a/tests/parallel_for/item_no_offset.cpp
+++ b/tests/parallel_for/item_no_offset.cpp
@@ -6,9 +6,9 @@
 
 using namespace cl::sycl;
 
-constexpr size_t N = 30;
-
 int main() {
+  constexpr size_t N = 30;
+
   {
     queue myQueue;
 

--- a/tests/pipe/1pipe_read_reserve.cpp
+++ b/tests/pipe/1pipe_read_reserve.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/1pipe_read_reserve.cpp
+++ b/tests/pipe/1pipe_read_reserve.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/1pipe_read_reserve.cpp
+++ b/tests/pipe/1pipe_read_reserve.cpp
@@ -62,7 +62,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
         { WI, WI },
         [=] (auto group) {
           // Use a sequential loop in the work-group to stream chunks in order
-          for (int start = 0; start != N; start += WI) {
+          for (int start = 0; start != (int)N; start += (int)WI) {
             /* To keep the reservation status outside the scope of the
                reservation itself */
             bool ok;

--- a/tests/pipe/1pipe_read_reserve.cpp
+++ b/tests/pipe/1pipe_read_reserve.cpp
@@ -10,15 +10,15 @@
 
 #include <boost/test/minimal.hpp>
 
-// Size of the buffers
-constexpr size_t N = 200;
-// Number of work-item per work-group
-constexpr size_t WI = 20;
-static_assert(N == WI*(N/WI), "N needs to be a multiple of WI");
-
-using Type = int;
-
 int test_main(int argc, char *argv[]) {
+  // Size of the buffers
+  constexpr size_t N = 200;
+  // Number of work-item per work-group
+  constexpr size_t WI = 20;
+  static_assert(N == WI*(N / WI), "N needs to be a multiple of WI");
+
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/pipe/1pipe_read_write_reserve.cpp
+++ b/tests/pipe/1pipe_read_write_reserve.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/1pipe_read_write_reserve.cpp
+++ b/tests/pipe/1pipe_read_write_reserve.cpp
@@ -13,15 +13,15 @@
 
 #include <boost/test/minimal.hpp>
 
-// Size of the buffers
-constexpr size_t N = 200;
-// Number of work-item per work-group
-constexpr size_t WI = 20;
-static_assert(N == WI*(N/WI), "N needs to be a multiple of WI");
-
-using Type = int;
-
 int test_main(int argc, char *argv[]) {
+  // Size of the buffers
+  constexpr size_t N = 200;
+  // Number of work-item per work-group
+  constexpr size_t WI = 20;
+  static_assert(N == WI*(N / WI), "N needs to be a multiple of WI");
+
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/pipe/1pipe_read_write_reserve.cpp
+++ b/tests/pipe/1pipe_read_write_reserve.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/1pipe_read_write_reserve.cpp
+++ b/tests/pipe/1pipe_read_write_reserve.cpp
@@ -51,7 +51,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
         { WI, WI },
         [=] (auto group) {
           // Use a sequential loop in the work-group to stream chunks in order
-          for (int start = 0; start != N; start += WI) {
+          for (int start = 0; start != (int)N; start += (int)WI) {
             /* To keep the reservation status outside the scope of the
                reservation itself */
             bool ok;
@@ -96,7 +96,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
           cl::sycl::pipe_reservation<decltype(apa)> r;
 #endif
           // Use a sequential loop in the work-group to stream chunks in order
-          for (int start = 0; start != N; start += WI) {
+          for (int start = 0; start != (int)N; start += (int)WI) {
             // Wait for the reservation to succeed
             while (!(r = apa.reserve(WI)))
               ;

--- a/tests/pipe/1pipe_write_reserve.cpp
+++ b/tests/pipe/1pipe_write_reserve.cpp
@@ -9,15 +9,15 @@
 
 #include <boost/test/minimal.hpp>
 
-// Size of the buffers
-constexpr size_t N = 200;
-// Number of work-item per work-group
-constexpr size_t WI = 20;
-static_assert(N == WI*(N/WI), "N needs to be a multiple of WI");
-
-using Type = int;
-
 int test_main(int argc, char *argv[]) {
+  // Size of the buffers
+  constexpr size_t N = 200;
+  // Number of work-item per work-group
+  constexpr size_t WI = 20;
+  static_assert(N == WI*(N / WI), "N needs to be a multiple of WI");
+
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/pipe/1pipe_write_reserve.cpp
+++ b/tests/pipe/1pipe_write_reserve.cpp
@@ -47,7 +47,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
         { WI, WI },
         [=] (auto group) {
           // Use a sequential loop in the work-group to stream chunks in order
-          for (int start = 0; start != N; start += WI) {
+          for (int start = 0; start != (int)N; start += (int)WI) {
             /* To keep the reservation status outside the scope of the
                reservation itself */
             bool ok;

--- a/tests/pipe/1pipe_write_reserve.cpp
+++ b/tests/pipe/1pipe_write_reserve.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/1pipe_write_reserve.cpp
+++ b/tests/pipe/1pipe_write_reserve.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/2_queues_pipe_producer_consumer.cpp
+++ b/tests/pipe/2_queues_pipe_producer_consumer.cpp
@@ -16,10 +16,10 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/pipe/3pipes_producer_consumer.cpp
+++ b/tests/pipe/3pipes_producer_consumer.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/pipe/3pipes_producer_consumer.cpp
+++ b/tests/pipe/3pipes_producer_consumer.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/test/minimal.hpp>
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 300;
   using Type = int;
 

--- a/tests/pipe/3pipes_producer_consumer.cpp
+++ b/tests/pipe/3pipes_producer_consumer.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/test/minimal.hpp>
 
-constexpr size_t N = 300;
-using Type = int;
-
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 300;
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/pipe/3pipes_reserve_producer_consumer.cpp
+++ b/tests/pipe/3pipes_reserve_producer_consumer.cpp
@@ -55,7 +55,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
         { WI, WI },
         [=] (auto group) {
           // Use a sequential loop in the work-group to stream chunks in order
-          for (int start = 0; start != N; start += WI) {
+          for (int start = 0; start != (int)N; start += (int)WI) {
             /* To keep the reservation status outside the scope of the
                reservation itself */
             bool ok;

--- a/tests/pipe/3pipes_reserve_producer_consumer.cpp
+++ b/tests/pipe/3pipes_reserve_producer_consumer.cpp
@@ -8,15 +8,15 @@
 #include <numeric>
 #include <boost/test/minimal.hpp>
 
-// Size of the buffers
-constexpr size_t N = 200;
-// Number of work-item per work-group
-constexpr size_t WI = 20;
-static_assert(N == WI*(N/WI), "N needs to be a multiple of WI");
-
-using Type = int;
-
 int test_main(int argc, char *argv[]) {
+  // Size of the buffers
+  constexpr size_t N = 200;
+  // Number of work-item per work-group
+  constexpr size_t WI = 20;
+  static_assert(N == WI*(N / WI), "N needs to be a multiple of WI");
+
+  using Type = int;
+
   // Initialize the input buffers to some easy-to-compute values
   cl::sycl::buffer<Type> a { N };
   {

--- a/tests/pipe/3pipes_reserve_producer_consumer.cpp
+++ b/tests/pipe/3pipes_reserve_producer_consumer.cpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <boost/test/minimal.hpp>
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/3pipes_reserve_producer_consumer.cpp
+++ b/tests/pipe/3pipes_reserve_producer_consumer.cpp
@@ -8,7 +8,7 @@
 #include <numeric>
 #include <boost/test/minimal.hpp>
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Size of the buffers
   constexpr size_t N = 200;
   // Number of work-item per work-group

--- a/tests/pipe/blocking_pipe_producer_consumer.cpp
+++ b/tests/pipe/blocking_pipe_producer_consumer.cpp
@@ -9,10 +9,10 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector va = { 1, 2, 3 };
   Vector vb = { 5, 6, 8 };
   Vector vc;

--- a/tests/pipe/blocking_pipe_producer_consumer_stream.cpp
+++ b/tests/pipe/blocking_pipe_producer_consumer_stream.cpp
@@ -9,10 +9,10 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector va = { 1, 2, 3 };
   Vector vb = { 5, 6, 8 };
   Vector vc;

--- a/tests/pipe/pipe_observers.cpp
+++ b/tests/pipe/pipe_observers.cpp
@@ -5,8 +5,6 @@
 #include <CL/sycl.hpp>
 #include <boost/test/minimal.hpp>
 
-constexpr size_t N = 3;
-
 
 /** A kernel to send a value into a pipe */
 auto send_element = [] (auto a_queue, cl::sycl::pipe<char> &a_pipe, char a_value) {
@@ -60,6 +58,8 @@ MAKE_GET_OBSERVER(capacity, std::size_t);
 
 
 int test_main(int argc, char *argv[]) {
+  constexpr size_t N = 3;
+
   // A pipe of N char elements
   cl::sycl::pipe<char> p { N };
 

--- a/tests/pipe/pipe_observers.cpp
+++ b/tests/pipe/pipe_observers.cpp
@@ -57,7 +57,7 @@ MAKE_GET_OBSERVER(size, std::size_t);
 MAKE_GET_OBSERVER(capacity, std::size_t);
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   constexpr size_t N = 3;
 
   // A pipe of N char elements

--- a/tests/pipe/pipe_observers.cpp
+++ b/tests/pipe/pipe_observers.cpp
@@ -57,7 +57,7 @@ MAKE_GET_OBSERVER(size, std::size_t);
 MAKE_GET_OBSERVER(capacity, std::size_t);
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   constexpr size_t N = 3;
 
   // A pipe of N char elements

--- a/tests/pipe/pipe_producer_consumer.cpp
+++ b/tests/pipe/pipe_producer_consumer.cpp
@@ -9,10 +9,10 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector va = { 1, 2, 3 };
   Vector vb = { 5, 6, 8 };
   Vector vc;

--- a/tests/pipe/pipe_producer_consumer_stream_syntax.cpp
+++ b/tests/pipe/pipe_producer_consumer_stream_syntax.cpp
@@ -10,10 +10,11 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
 
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector a = { 1, 2, 3 };
   Vector b = { 5, 6, 8 };
   Vector c;

--- a/tests/pipe/static_pipe_producer_consumer.cpp
+++ b/tests/pipe/static_pipe_producer_consumer.cpp
@@ -6,13 +6,13 @@
 #include <iostream>
 #include <iterator>
 
-constexpr size_t N = 3;
-using Vector = float[N];
-
 // A static-scoped pipe of 4 float elements
-cl::sycl::static_pipe<float, 4> p;
+cl::sycl::static_pipe<float, 4> pipe;
 
 int main() {
+  constexpr size_t N = 3;
+  using Vector = float[N];
+
   Vector va = { 1, 2, 3 };
   Vector vb = { 5, 6, 8 };
   Vector vc;
@@ -31,7 +31,7 @@ int main() {
     // Launch the producer to stream A to the pipe
     q.submit([&](cl::sycl::handler &cgh) {
       // Get write access to the pipe
-      auto kp = p.get_access<cl::sycl::access::mode::write>(cgh);
+      auto kp = pipe.get_access<cl::sycl::access::mode::write>(cgh);
       // Get read access to the data
       auto ka = ba.get_access<cl::sycl::access::mode::read>(cgh);
 
@@ -46,7 +46,7 @@ int main() {
     // Launch the consumer that adds the pipe stream with B to C
     q.submit([&](cl::sycl::handler &cgh) {
       // Get read access to the pipe
-      auto kp = p.get_access<cl::sycl::access::mode::read>(cgh);
+      auto kp = pipe.get_access<cl::sycl::access::mode::read>(cgh);
 
       // Get access to the input/output buffers
       auto kb = bb.get_access<cl::sycl::access::mode::read>(cgh);

--- a/tests/platform/default_platform.cpp
+++ b/tests/platform/default_platform.cpp
@@ -29,7 +29,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   check_all<platform>();
   platform p;
   display(p);

--- a/tests/platform/default_platform.cpp
+++ b/tests/platform/default_platform.cpp
@@ -44,9 +44,9 @@ int test_main(int argc, char *argv[]) {
 //  std::cout << "(p == p2) should be printed as 1: " << (p == p2) << std::endl
 //            << std::endl;
 
-  for (const auto &p : platform::get_platforms()) {
-    std::cout << "Platform " << &p << ':' << std::endl;
-    display(p);
+  for (const auto &plat : platform::get_platforms()) {
+    std::cout << "Platform " << &plat << ':' << std::endl;
+    display(plat);
   }
 
   // Verify that get() throws since there is no OpenCL behind the curtain

--- a/tests/platform/default_platform.cpp
+++ b/tests/platform/default_platform.cpp
@@ -29,7 +29,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   check_all<platform>();
   platform p;
   display(p);

--- a/tests/platform/opencl_platform.cpp
+++ b/tests/platform/opencl_platform.cpp
@@ -14,7 +14,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   check_all<platform>(boost::compute::system::platforms()[0]);
   platform p { boost::compute::system::platforms()[0] };
   display(p);

--- a/tests/platform/opencl_platform.cpp
+++ b/tests/platform/opencl_platform.cpp
@@ -14,7 +14,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   check_all<platform>(boost::compute::system::platforms()[0]);
   platform p { boost::compute::system::platforms()[0] };
   display(p);

--- a/tests/queue/default_queue.cpp
+++ b/tests/queue/default_queue.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   check_all<queue>({});
   queue q;
 

--- a/tests/queue/default_queue.cpp
+++ b/tests/queue/default_queue.cpp
@@ -10,7 +10,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   check_all<queue>({});
   queue q;
 

--- a/tests/queue/opencl_queue.cpp
+++ b/tests/queue/opencl_queue.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   // Start from an OpenCL queue
   auto oq = boost::compute::system::default_queue();
   // Construct a SYCL queue from it

--- a/tests/queue/opencl_queue.cpp
+++ b/tests/queue/opencl_queue.cpp
@@ -9,7 +9,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   // Start from an OpenCL queue
   auto oq = boost::compute::system::default_queue();
   // Construct a SYCL queue from it

--- a/tests/range/range.cpp
+++ b/tests/range/range.cpp
@@ -38,7 +38,7 @@
 using namespace cl::sycl;
 
 // To test the inference of the range rank
-template<int N> void f(range<N> r) {
+template<int N> void f(range<N>) {
   std::cout << "Range of dims " << N << std::endl;
 }
 

--- a/tests/range/range_size.cpp
+++ b/tests/range/range_size.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
   range<1> r1 { 8 };
   BOOST_CHECK(r1.size() == 1);
   BOOST_CHECK(r1.get_count() == 8);

--- a/tests/range/range_size.cpp
+++ b/tests/range/range_size.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
   range<1> r1 { 8 };
   BOOST_CHECK(r1.size() == 1);
   BOOST_CHECK(r1.get_count() == 8);

--- a/tests/vector/operators.cpp
+++ b/tests/vector/operators.cpp
@@ -47,7 +47,7 @@ auto equal = [] (auto const &v, auto const &verif) {
   }
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr size_t N = 16;
   { // By sticking all the SYCL work in a {} block, we ensure

--- a/tests/vector/operators.cpp
+++ b/tests/vector/operators.cpp
@@ -28,22 +28,22 @@ auto equal = [] (auto const &v, auto const &verif) {
 */
 #define TRISYCL_CHECK(OPERATOR, TYPE, SIZE, VAL1, VAL2) \
   {                                                     \
-    std::initializer_list<TYPE> vil1 VAL1;              \
-    std::initializer_list<TYPE> vil2 VAL2;              \
-    using v = vec<TYPE, SIZE>;                          \
-    using va = std::valarray<TYPE>;                     \
-    v v1 VAL1;                                          \
-    v v2 VAL2;                                          \
-    v v3 = v1 OPERATOR v2;                              \
-    va va1 { vil1 };                                    \
-    va va2 { vil2 };                                    \
-    va va3 = va1 OPERATOR va2;                          \
-    BOOST_CHECK(equal(v1, va1));                        \
-    BOOST_CHECK(equal(v2, va2));                        \
-    BOOST_CHECK(equal(v3, va3));                        \
-    v3 OPERATOR##= v1;                                  \
-    va3 OPERATOR##= va1;                                \
-    BOOST_CHECK(equal(v3, va3));                        \
+    std::initializer_list<TYPE> _vil1 VAL1;             \
+    std::initializer_list<TYPE> _vil2 VAL2;             \
+    using _v = vec<TYPE, SIZE>;                         \
+    using _va = std::valarray<TYPE>;                    \
+    _v _v1 VAL1;                                        \
+    _v _v2 VAL2;                                        \
+    _v _v3 = _v1 OPERATOR _v2;                          \
+    _va _va1 { _vil1 };                                 \
+    _va _va2 { _vil2 };                                 \
+    _va _va3 = _va1 OPERATOR _va2;                      \
+    BOOST_CHECK(equal(_v1, _va1));                      \
+    BOOST_CHECK(equal(_v2, _va2));                      \
+    BOOST_CHECK(equal(_v3, _va3));                      \
+    _v3 OPERATOR##= _v1;                                \
+    _va3 OPERATOR##= _va1;                              \
+    BOOST_CHECK(equal(_v3, _va3));                      \
   }
 
 

--- a/tests/vector/operators.cpp
+++ b/tests/vector/operators.cpp
@@ -47,7 +47,7 @@ auto equal = [] (auto const &v, auto const &verif) {
   }
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr size_t N = 16;
   { // By sticking all the SYCL work in a {} block, we ensure
@@ -65,7 +65,7 @@ int test_main(int argc, char *argv[]) {
       auto kc = C.get_access<access::mode::write>(cgh);
 
       cgh.parallel_for<class generate>(range<1> { N },
-                                       [=] (id<1> index) {
+                                       [=] (id<1>) {
         vec<float, 4> v1 { 1, 2, 3, 4};
         vec<float, 4> v2 { 4, 5, 6, 7};
         auto v3 = v1 * v2;

--- a/tests/vector/vec.cpp
+++ b/tests/vector/vec.cpp
@@ -25,7 +25,7 @@ bool equal(const Vec &v, const Vec &verif) {
 
 
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 
   constexpr size_t N = 16;
   { // By sticking all the SYCL work in a {} block, we ensure
@@ -43,7 +43,7 @@ int test_main(int argc, char *argv[]) {
       auto kc = C.get_access<access::mode::write>(cgh);
 
       cgh.parallel_for<class generate>(range<1> { N },
-                                       [=] (id<1> index) {
+                                       [=] (id<1>) {
         vec<float, 16> v;
         float1 v1 = 1.5F;
         BOOST_CHECK(equal(v1, { 1.5F }));

--- a/tests/vector/vec.cpp
+++ b/tests/vector/vec.cpp
@@ -25,7 +25,7 @@ bool equal(const Vec &v, const Vec &verif) {
 
 
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 
   constexpr size_t N = 16;
   { // By sticking all the SYCL work in a {} block, we ensure

--- a/tests/vector/vec.cpp
+++ b/tests/vector/vec.cpp
@@ -44,7 +44,7 @@ int test_main(int /*argc*/, char*[] /*argv*/) {
 
       cgh.parallel_for<class generate>(range<1> { N },
                                        [=] (id<1>) {
-        vec<float, 16> v;
+        vec<float, 16> v; static_cast<void>(v); //unused local var
         float1 v1 = 1.5F;
         BOOST_CHECK(equal(v1, { 1.5F }));
         auto v1_1 = v1 + v1;

--- a/tests/vector/vecacc.cpp
+++ b/tests/vector/vecacc.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int /*argc*/, char** /**argv[]*/) {
+int test_main(int /*argc*/, char*[] /*argv*/) {
 	vec<int, 3> v = {1, 2, 3};
 	BOOST_CHECK(v.x() == 1);
 	BOOST_CHECK(v.y() == 2);

--- a/tests/vector/vecacc.cpp
+++ b/tests/vector/vecacc.cpp
@@ -8,7 +8,7 @@
 
 using namespace cl::sycl;
 
-int test_main(int argc, char *argv[]) {
+int test_main(int /*argc*/, char** /**argv[]*/) {
 	vec<int, 3> v = {1, 2, 3};
 	BOOST_CHECK(v.x() == 1);
 	BOOST_CHECK(v.y() == 2);


### PR DESCRIPTION
Although there was explicit statement that we wanted to eliminate all warnings, I believe it would benefit all, if we could develop new features on the highest warning level of all compilers and receive messages only related to the feature being implemented.

As it stands, it is by far a non-zero amount of work, so I wanted to break down this "feature" implementation into to parts, in case there would be no consensus this is desired feature. Most of the warnings were not actual errors in the code, but all of them are useful to identify potential warnings.

## Some notes
The PR surely needs additional commits, as the code isn't clean. In most cases I just wanted to mark code that triggers warnings and silence them.

### warning C4456: declaration of '<id>' hides previous local declaration
This is fairly straightforward. Triggers when one overrides a scoped variable name locally, for instance int i with the running index of a for loop. This mostly triggered due to template code overriding variables in the cpp files. Not an error, as the template code surely did not wish to reference the cpp version of the variables.

### warning C4127: conditional expression is constant
Probably the most noisy change. It is supposed to trigger on cases such as if(true) and if(false). It also triggers however on template code, in cases where the boolean is a constexpr value. To silence the warning, I changed it to proper template code. (Although I recall not trying assigning the value to a runtime variable.) Should be vastly cleaner one if constexpr() will be widely supported.

### warning C4459: declaration of '<id>' hides global declaration
Similar to the local case, this triggers when template code created variables that are global variables in the cpp and they are hidden. I made those variables local in the cpp, as in most cases they were not needed to be global variables. (Bad practice in my view. I try avoiding global variables whenever possible.)

### warning C4100: '<param>': unreferenced formal parameter
Triggers when function parameters are given names, but then are not used. I mostly commented out their names, as they occured in unimplemented functions, but I wanted to leave a mark of their nature. (What does a string_type param refer to? Id? extension name?) When it was the last param and was given a default value, I couldn't comment it out as it changes the overload set and breaks code. In these cases, I mentioned them in the functions body and noted.

Most notably in the case of allocators it was strange we never use them.

## Onward
If you think this is a worthwhile effort, I will go on with Warning Level 3 messages. Once I finish, I believe there will be much less work for fixing all issues to have GCC and Clang compile warning free as well. Most noisy of all on Ubuntu 16.04 with stock OpenCL headers is

### warning: ignoring attributes on template argument
Triggers when the template machinery strips GCC specific attributes from template parameters (just about EVERY template function inside Boost Compute).