### PR TITLE
Improve Travis-CI build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: cpp
 
 services:
     - docker
+
 env:
   matrix:
     - CC_BUILD=gcc-6
@@ -16,10 +17,34 @@ env:
       OPENMP=ON
       OPENCL=OFF
 
+    - CC_BUILD=gcc-6
+      CXX_BUILD=g++-6
+      OPENMP=ON
+      OPENCL=ON
+
+    - CC_BUILD=clang-4.0
+      CXX_BUILD=clang++-4.0
+      OPENMP=ON
+      OPENCL=ON
+
 before_install:
-    - docker build -t trisycl .
+    - |
+      if [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
+         export GIT_SLUG=${TRAVIS_REPO_SLUG}
+         export GIT_BRANCH=${TRAVIS_BRANCH}
+      else
+         export GIT_SLUG=${TRAVIS_PULL_REQUEST_SLUG}
+         export GIT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH}
+      fi
+    - echo "Git repo | branch -> ${GIT_SLUG} | ${GIT_BRANCH}"
+    - docker build --build-arg cxx_compiler=${CXX_BUILD}
+                   --build-arg c_compiler=${CC_BUILD}
+                   --build-arg git_branch=${GIT_BRANCH}
+                   --build-arg git_slug=${GIT_SLUG}
+                   --build-arg openmp=${OPENMP}
+                   --build-arg opencl=${OPENCL} -t trisycl .
     - docker ps -a
     - docker images
 
 script:
-    - docker run -e COMPILER=${CXX_BUILD} -e C_COMPILER=${CC_BUILD} -e OPENMP=${OPENMP} -e OPENCL=${OPENCL} trisycl
+    - docker run trisycl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,42 @@
 FROM ubuntu:zesty
 
-RUN apt-get -y update
-RUN apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages git wget apt-utils cmake opencl-headers
-RUN apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages clang-4.0 g++-6 gcc-6 libboost-all-dev libomp-dev
-RUN git clone https://github.com/triSYCL/triSYCL.git -b master /root/trisycl
+# Default values for the build
+ARG c_compiler=gcc-6
+ARG cxx_compiler=g++-6
+ARG opencl=ON
+ARG openmp=ON
+ARG git_branch=master
+ARG git_slug=triSYCL/triSYCL
 
-CMD cd /root/trisycl; cmake . -DBUILD_OPENCL=${OPENCL} -DTRISYCL_OPENMP=${OPENMP} \
-    -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${COMPILER}             \
-    && make && ctest
+RUN apt-get -y update
+
+# Utilities
+RUN apt-get install -y --allow-downgrades --allow-remove-essential             \
+    --allow-change-held-packages git wget apt-utils cmake libboost-all-dev
+
+# Clang 4.0
+RUN if [ "${c_compiler}" = 'clang-4.0' ]; then apt-get install -y              \
+    --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
+     clang-4.0; fi
+
+# GCC 6
+RUN if [ "${c_compiler}" = 'gcc-6' ]; then apt-get install -y                  \
+    --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
+    g++-6 gcc-6; fi
+
+# OpenMP
+RUN if [ "${openmp}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
+    --allow-remove-essential --allow-change-held-packages libomp-dev; fi
+
+#OpenCL with POCL
+RUN if [ "${opencl}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
+    --allow-remove-essential --allow-change-held-packages opencl-headers       \
+    ocl-icd-opencl-dev libpocl-dev libpocl1 libpoclu1 pocl-opencl-icd; fi
+
+RUN git clone https://github.com/${git_slug}.git -b ${git_branch} /trisycl
+
+RUN cd /trisycl; cmake . -DBUILD_OPENCL=${opencl}                              \
+    -DTRISYCL_OPENMP=${openmp} -DCMAKE_C_COMPILER=${c_compiler}                \
+    -DCMAKE_CXX_COMPILER=${cxx_compiler} && make -j 4
+
+CMD cd /trisycl && make -j 2 && ctest

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 triSYCL
 +++++++
 
+.. image:: https://travis-ci.org/triSYCL/triSYCL.svg?branch=master
+    :target: https://travis-ci.org/triSYCL/triSYCL
+
 News
 ----
 


### PR DESCRIPTION
### Changes

- Enable build with clang-4 and gcc-6 with or without OpenCL or OpenMP
- Use POCL as the OpenMP implementation
- Add the travis-ci build icon in the README
- Configure Docker to build the right branch depending on the origin of the build (commit or pull request)