### PR TITLE
Fix compile error in buffer test

### DIFF
--- a/tests/buffer/buffer_unique_ptr.cpp
+++ b/tests/buffer/buffer_unique_ptr.cpp
@@ -14,7 +14,7 @@ int test_main(int argc, char *argv[]) {
   constexpr size_t N = 16;
 
   // Allocate some memory to test ownership give-away
-  std::unique_ptr<int[]> init { new int[N] };
+  std::unique_ptr<int> init { new int[N] };
   std::iota(init.get(), init.get() + N, 314);
 
   buffer<int> a { std::move(init), N };


### PR DESCRIPTION
Fix incorrect unique_ptr type in buffer ownership test. This would lead to compile error on line 20.