### PR TITLE
Fix compilation issue with GCC 7.1 & Clang with libc++

### DIFF
--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -232,33 +232,6 @@ public:
   {}
 
 
-  /** Create a new buffer which is initialized by host_data
-
-      \param[in] host_data points to the storage and values used to
-      initialize the buffer
-
-      \param[in] r defines the size
-
-      \param[in] allocator is to be used by the SYCL runtime, of type
-      cl::sycl::buffer_allocator<T> by default
-
-      The SYCL runtime receives full ownership of the host_data unique_ptr
-      and there in effect there is no synchronization with the application
-      code using host_data.
-
-      \todo Update the API to add template <typename D =
-      std::default_delete<T>> because the
-      unique_ptr_class/std::unique_ptr have the destructor type as
-      dependent
-  */
-  buffer(unique_ptr_class<T> &&host_data,
-         const range<Dimensions> &r,
-         Allocator allocator = {})
-    : implementation_t { detail::waiter(new detail::buffer<T, Dimensions>
-                         { std::move(host_data), r }) }
-  {}
-
-
   /** Create a new allocated 1D buffer initialized from the given
       elements ranging from first up to one before last
 

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -157,31 +157,6 @@ public:
   {}
 
 
-  /** Create a new buffer with associated memory, using the data owned in
-      a unique pointer
-
-      SYCL's runtime has full ownership of the host_data.
-  */
-  template<typename Deleter>
-  buffer(unique_ptr_class<T, Deleter> &&host_data,
-         const range<Dimensions> &r) :
-    access { host_data.get(), r },
-      /* Use the fact that there is an implicit constructor of a \c
-         std::shared_ptr from a \c std::unique_ptr to avoid storing
-         the unique pointer. Doing so would need to implement
-         ourselves some type erasure on the \c Deleter to avoid it
-         leaking out of the \c buffer type and \c accessor type.
-
-         It still works as expected since, if we own a shared pointer,
-         the \c Deleter is correctly handled and if we own it and its
-         use-count is 1, we are the only owner and we can skip the
-         copy-back later.
-       */
-    input_shared_pointer { std::move(host_data) },
-    data_host { true }
-  {}
-
-
   /// Create a new allocated 1D buffer from the given elements
   template <typename Iterator>
   buffer(Iterator start_iterator, Iterator end_iterator) :

--- a/tests/buffer/buffer_unique_ptr.cpp
+++ b/tests/buffer/buffer_unique_ptr.cpp
@@ -13,8 +13,26 @@ int test_main(int argc, char *argv[]) {
 
   constexpr size_t N = 16;
 
-  // Allocate some memory to test ownership give-away
-  std::unique_ptr<int[]> init { new int[N] };
+  /* Allocate some memory to test ownership give-away
+
+     Interestingly, we cannot have directly
+     \code
+     std::unique_ptr<int[]> init { new int[N] };
+     \endcode
+     because there is the buffer constructor take a \c
+     std::shared_ptr<T> and in C++17 there is an implicit conversion
+     from \c std::unique_ptr<T[]> to \c std::shared_ptr<T[]> and
+     another one \c std::shared_ptr<T[]> to \c std::shared_ptr<T>, but
+     globally it requires chaining more than 1 implicit conversion and
+     thus it is not tried.
+
+     Should we provide a \c std::unique_ptr<T[]> for buffer in the
+     SYCL specification?
+
+     Or is there a missing \c std::shared_ptr<T> constructor from a \c
+     std::unique_ptr<T[]> in C++17?
+  */
+  std::unique_ptr<int, std::default_delete<int[]>> init { new int[N] };
   std::iota(init.get(), init.get() + N, 314);
 
   buffer<int> a { std::move(init), N };


### PR DESCRIPTION
This should fix https://github.com/triSYCL/triSYCL/issues/48

Also remove buffer construction from a std::unique_ptr according to latest SYCL specification, since the std::shared_ptr constructor is enough.