### PR TITLE
Rename SYCL 1.2 member function group::get() to SYCL 1.2.1 group::get_id()

### DIFF
--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -80,11 +80,11 @@ public:
   /** Return an id representing the index of the group within the nd_range
       for every dimension
   */
-  id<Dimensions> get() const { return group_id; }
+  id<Dimensions> get_id() const { return group_id; }
 
 
   /// Return the index of the group in the given dimension
-  size_t get(int dimension) const { return get()[dimension]; }
+  size_t get_id(int dimension) const { return get_id()[dimension]; }
 
 
   /** Return the index of the group in the given dimension within the
@@ -170,7 +170,7 @@ public:
 
    */
   size_t get_linear() const {
-    return detail::linear_id(get_group_range(), get());
+    return detail::linear_id(get_group_range(), get_id());
   }
 
 

--- a/include/CL/sycl/parallelism/detail/parallelism.hpp
+++ b/include/CL/sycl/parallelism/detail/parallelism.hpp
@@ -335,7 +335,7 @@ void parallel_for_workitem(const group<Dimensions> &g,
         local[2] = th_id % l_r.get(2);
       }
       index.set_local(local);
-      index.set_global(local + id<Dimensions>(l_r)*g.get());
+      index.set_global(local + id<Dimensions>(l_r)*g.get_id());
       f(index);
     }
   }

--- a/include/CL/sycl/parallelism/detail/parallelism.hpp
+++ b/include/CL/sycl/parallelism/detail/parallelism.hpp
@@ -352,7 +352,7 @@ void parallel_for_workitem(const group<Dimensions> &g,
     // Reconstruct the global nd_item
     index.set_local(local);
     // \todo Some strength reduction here
-    index.set_global(local + id<Dimensions>(g.get_local_range())*g.get());
+    index.set_global(local + id<Dimensions>(g.get_local_range())*g.get_id());
     // Call the user kernel at last
     f(index);
   };

--- a/tests/address_spaces/address_spaces_pstl.cpp
+++ b/tests/address_spaces/address_spaces_pstl.cpp
@@ -97,7 +97,7 @@ B buffer_map2reduce(ExecutionPolicy &snp,
       sum { cl::sycl::range<1>(d.nb_work_item), cgh };
     auto sumX = cl::sycl::local_ptr<B> { sum };
     cgh.parallel_for_work_group<class wg>(rng, [=](cl::sycl::group<1> grp) {
-      size_t group_id = grp.get(0);
+      size_t group_id = grp.get_id(0);
       //assert(group_id < d.nb_work_group);
       size_t group_begin = group_id * d.size_per_work_group;
       size_t group_end = min((group_id+1) * d.size_per_work_group, d.size);

--- a/tests/group/group.cpp
+++ b/tests/group/group.cpp
@@ -66,7 +66,7 @@ auto display_test = [](auto ndi) {
   ndi.get_offset().display();
   DISPLAY_ELEMENTS(get_offset);
   ndi.get_id().display();
-  DISPLAY_ELEMENTS(get);
+  DISPLAY_ELEMENTS(get_id);
   std::cout << ndi.get_linear() << std::endl;
 };
 

--- a/tests/group/group.cpp
+++ b/tests/group/group.cpp
@@ -65,7 +65,7 @@ auto display_test = [](auto ndi) {
   DISPLAY_ELEMENTS(get_local_range);
   ndi.get_offset().display();
   DISPLAY_ELEMENTS(get_offset);
-  ndi.get().display();
+  ndi.get_id().display();
   DISPLAY_ELEMENTS(get);
   std::cout << ndi.get_linear() << std::endl;
 };

--- a/tests/jacobi/include/stencil-fxd.hpp
+++ b/tests/jacobi/include/stencil-fxd.hpp
@@ -196,7 +196,7 @@ public:
 
   inline void store_local(T * local_tab, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in, cl::sycl::nd_item<2> it, cl::sycl::group<2> gr, int glob_max0, int glob_max1) {
     cl::sycl::range<2> l_range = it.get_local_range();
-    cl::sycl::id<2> g_ind = gr.get(); //it.get_group_id(); error because ambiguous / operator redefinition 
+    cl::sycl::id<2> g_ind = gr.get_id(); //it.get_group_id(); error because ambiguous / operator redefinition 
     cl::sycl::id<2> l_ind = it.get_local();
 
     int l_range0 = l_range.get(0);

--- a/tests/jacobi/include/stencil-gen-var.hpp
+++ b/tests/jacobi/include/stencil-gen-var.hpp
@@ -175,7 +175,7 @@ public:
   // Not really static because of the use of global_max (which is passed by args)
   static inline void store_local(T * local_tab, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in, cl::sycl::nd_item<2> it, cl::sycl::group<2> gr, int glob_max0, int glob_max1) {
     cl::sycl::range<2> l_range = it.get_local_range();
-    cl::sycl::id<2> g_ind = gr.get(); //it.get_group_id(); error because ambiguous / operator redefinition 
+    cl::sycl::id<2> g_ind = gr.get_id(); //it.get_group_id(); error because ambiguous / operator redefinition 
     cl::sycl::id<2> l_ind = it.get_local();
 
     int l_range0 = l_range.get(0);

--- a/tests/jacobi/include/stencil-var.hpp
+++ b/tests/jacobi/include/stencil-var.hpp
@@ -176,7 +176,7 @@ public:
   // Not really static because of the use of global_max (which is passed by args)
   static inline void store_local(T * local_tab, cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> in, cl::sycl::nd_item<2> it, cl::sycl::group<2> gr, int glob_max0, int glob_max1) {
     cl::sycl::range<2> l_range = it.get_local_range();
-    cl::sycl::id<2> g_ind = gr.get(); //it.get_group_id(); error because ambiguous / operator redefinition 
+    cl::sycl::id<2> g_ind = gr.get_id(); //it.get_group_id(); error because ambiguous / operator redefinition 
     cl::sycl::id<2> l_ind = it.get_local();
 
     int l_range0 = l_range.get(0);

--- a/tests/multiple_compilation_units/parallel_for.cc
+++ b/tests/multiple_compilation_units/parallel_for.cc
@@ -30,7 +30,7 @@ int test_main(int argc, char *argv[]) {
         nd_range<> { range<> { size }, range<> { groupsize } },
         [=](group<> group) {
           parallel_for_work_item(group, [=](nd_item<1> tile) {
-              out_access[tile] = 1000*group.get(0) + tile.get_local(0);
+              out_access[tile] = 1000*group.get_id(0) + tile.get_local(0);
             });
         });
     });

--- a/tests/parallel_for/hierarchical.cpp
+++ b/tests/parallel_for/hierarchical.cpp
@@ -47,7 +47,7 @@ my_queue.submit([&](handler &cgh)
                                                              range<>(groupsize)),
                                                   [=](group<> group)
   {
-    std::cout << "Group id = " << group.get(0) << std::endl;
+    std::cout << "Group id = " << group.get_id(0) << std::endl;
 
     parallel_for_work_item(group, [=](nd_item<1> tile)
     {

--- a/tests/parallel_for/hierarchical_new.cpp
+++ b/tests/parallel_for/hierarchical_new.cpp
@@ -55,7 +55,7 @@ my_queue.submit([&](handler &cgh) {
   cgh.parallel_for_work_group<class hierarchical>(nd_range<>(range<>(size),
                                                              range<>(groupsize)),
                                                   [=](group<> group) {
-    std::cout << "Group id = " << group.get(0) << std::endl;
+    std::cout << "Group id = " << group.get_id(0) << std::endl;
 
     group.parallel_for_work_item([=](nd_item<1> tile) {
       std::cout << "Local id = " << tile.get_local(0)


### PR DESCRIPTION
Fix for issue #119 