### PR TITLE
Fix typo in CMake MSVC detection

### DIFF
--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -73,7 +73,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options("-Wno-undefined-var-template")
 
   endif()
-elseif ("${CMAKE_CXX_COMPILIER_ID}" STREQUAL "MSVC")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # Change to /std:c++latest once Boost::funtional is fixed
   # (1.63.0 with toolset v141 not working)
   add_compile_options("/std:c++14")


### PR DESCRIPTION
Fix a small typo ("COMPILIER") that breaks the MSVC compiler detection in FindTriSYCL.cmake