### PR TITLE
Update Travis CI to Ubuntu 17.10, GCC 7 and Clang 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,23 @@ services:
 
 env:
   matrix:
-    - CC_BUILD=gcc-6
-      CXX_BUILD=g++-6
+    - CC_BUILD=gcc-7
+      CXX_BUILD=g++-7
       OPENMP=ON
       OPENCL=OFF
 
-    - CC_BUILD=clang-4.0
-      CXX_BUILD=clang++-4.0
+    - CC_BUILD=clang-5.0
+      CXX_BUILD=clang++-5.0
       OPENMP=ON
       OPENCL=OFF
 
-    - CC_BUILD=gcc-6
-      CXX_BUILD=g++-6
+    - CC_BUILD=gcc-7
+      CXX_BUILD=g++-7
       OPENMP=ON
       OPENCL=ON
 
-    - CC_BUILD=clang-4.0
-      CXX_BUILD=clang++-4.0
+    - CC_BUILD=clang-5.0
+      CXX_BUILD=clang++-5.0
       OPENMP=ON
       OPENCL=ON
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:zesty
+FROM ubuntu:artful
 
 # Default values for the build
-ARG c_compiler=gcc-6
-ARG cxx_compiler=g++-6
+ARG c_compiler=gcc-7
+ARG cxx_compiler=g++-7
 ARG opencl=ON
 ARG openmp=ON
 ARG git_branch=master
@@ -14,15 +14,15 @@ RUN apt-get -y update
 RUN apt-get install -y --allow-downgrades --allow-remove-essential             \
     --allow-change-held-packages git wget apt-utils cmake libboost-all-dev
 
-# Clang 4.0
-RUN if [ "${c_compiler}" = 'clang-4.0' ]; then apt-get install -y              \
+# Clang 5.0
+RUN if [ "${c_compiler}" = 'clang-5.0' ]; then apt-get install -y              \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-     clang-4.0; fi
+     clang-5.0; fi
 
-# GCC 6
-RUN if [ "${c_compiler}" = 'gcc-6' ]; then apt-get install -y                  \
+# GCC 7
+RUN if [ "${c_compiler}" = 'gcc-7' ]; then apt-get install -y                  \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-    g++-6 gcc-6; fi
+    g++-7 gcc-7; fi
 
 # OpenMP
 RUN if [ "${openmp}" = 'ON' ]; then apt-get install -y --allow-downgrades      \


### PR DESCRIPTION
Since support of 17.04 Zesty Zapus just stopped on January 13, 2018
and broke the triSYCL CI, take the opportunity to use more recent
compiler versions too.