### PR TITLE
Update Travis CI to Ubuntu 18.04, GCC 8 and Clang 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,23 @@ services:
 
 env:
   matrix:
-    - CC_BUILD=gcc-7
-      CXX_BUILD=g++-7
+    - CC_BUILD=gcc-8
+      CXX_BUILD=g++-8
       OPENMP=ON
       OPENCL=OFF
 
-    - CC_BUILD=clang-5.0
-      CXX_BUILD=clang++-5.0
+    - CC_BUILD=clang-6.0
+      CXX_BUILD=clang++-6.0
       OPENMP=ON
       OPENCL=OFF
 
-    - CC_BUILD=gcc-7
-      CXX_BUILD=g++-7
+    - CC_BUILD=gcc-8
+      CXX_BUILD=g++-8
       OPENMP=ON
       OPENCL=ON
 
-    - CC_BUILD=clang-5.0
-      CXX_BUILD=clang++-5.0
+    - CC_BUILD=clang-6.0
+      CXX_BUILD=clang++-6.0
       OPENMP=ON
       OPENCL=ON
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ env:
       OPENMP=ON
       OPENCL=OFF
 
-    - CC_BUILD=gcc-8
-      CXX_BUILD=g++-8
+      # There is a bug with shipped version of Boost.Compute incompatible
+      # with g++-8
+    - CC_BUILD=gcc-7
+      CXX_BUILD=g++-7
       OPENMP=ON
       OPENCL=ON
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 # Default values for the build
-ARG c_compiler=gcc-7
-ARG cxx_compiler=g++-7
+ARG c_compiler=gcc-8
+ARG cxx_compiler=g++-8
 ARG opencl=ON
 ARG openmp=ON
 ARG git_branch=master
@@ -14,21 +14,21 @@ RUN apt-get -y update
 RUN apt-get install -y --allow-downgrades --allow-remove-essential             \
     --allow-change-held-packages git wget apt-utils cmake libboost-all-dev
 
-# Clang 5.0
-RUN if [ "${c_compiler}" = 'clang-5.0' ]; then apt-get install -y              \
+# Clang 6.0
+RUN if [ "${c_compiler}" = 'clang-6.0' ]; then apt-get install -y              \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-     clang-5.0; fi
+     clang-6.0; fi
 
-# GCC 7
-RUN if [ "${c_compiler}" = 'gcc-7' ]; then apt-get install -y                  \
+# GCC 8
+RUN if [ "${c_compiler}" = 'gcc-8' ]; then apt-get install -y                  \
     --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-    g++-7 gcc-7; fi
+    g++-8 gcc-8; fi
 
 # OpenMP
 RUN if [ "${openmp}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
     --allow-remove-essential --allow-change-held-packages libomp-dev; fi
 
-#OpenCL with POCL
+# OpenCL with POCL
 RUN if [ "${opencl}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
     --allow-remove-essential --allow-change-held-packages opencl-headers       \
     ocl-icd-opencl-dev libpocl-dev libpocl1 libpoclu1 pocl-opencl-icd; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN if [ "${openmp}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
 # OpenCL with POCL
 RUN if [ "${opencl}" = 'ON' ]; then apt-get install -y --allow-downgrades      \
     --allow-remove-essential --allow-change-held-packages opencl-headers       \
-    ocl-icd-opencl-dev libpocl-dev libpocl1 libpoclu1 pocl-opencl-icd; fi
+    ocl-icd-opencl-dev libpocl-dev ; fi
 
 RUN git clone https://github.com/${git_slug}.git -b ${git_branch} /trisycl
 

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -152,7 +152,8 @@ it to some target device and at the same time to compile on the host side
 some glue code around the extraction boundary to transfer data to and
 from the device and call the kernel itself.
 
-The device compiler is based on Clang/LLVM 3.9 for now.
+The device compiler is based on Clang/LLVM 3.9 for now but there are
+some experiments with Clang/LLVM 7 too.
 
 Since it is quite more experimental than the CPU path, it is not yet
 merged into the main branches:
@@ -165,6 +166,9 @@ merged into the main branches:
 
 - LLVM supporting triSYCL:
   https://github.com/triSYCL/llvm/tree/sycl/release_39/master
+
+For CLang/LLVM 7, you might look at the branches
+`sycl/release_70/lin-ya` or `sycl/release_70/master`.
 
 
 Installation & compilation

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,12 +3,12 @@
 # See doc/macros.rst for a description of triSYCL-specific macros.
 
 # Set default compiler instead of default CXX=g++ value
-# Assume Clang 3.9 and libc++ or Clang 4.0 with libstdc++ at least
-CXX = clang++-5.0
+# Assume some recent compiler
+CXX = clang++-6.0
 # To use libc++ instead of libstdc++, from libc++-dev & libc++abi-dev packages
 #CXXFLAGS += -stdlib=libc++
 
-# But everything works fine with GCC 5.4 at least
+# But everything works fine with GCC 7 at least
 #CXX = g++
 
 # The device compiler to use.

--- a/tests/pipe/pipe_observers.cpp
+++ b/tests/pipe/pipe_observers.cpp
@@ -44,7 +44,7 @@ auto get_##METHOD = [] (auto &a_queue, cl::sycl::pipe<char> &a_pipe) {  \
       /* Get write access to write back the value returned by the observer */ \
       const auto v = value.get_access<cl::sycl::access::mode::write>(cgh);    \
                                                                         \
-      cgh.single_task([=] {                                             \
+      cgh.single_task([=] () mutable {                                  \
           *v = p.METHOD();                                              \
         });                                                             \
       });                                                               \


### PR DESCRIPTION
Now there is more and more C++17 features in triSYCL, switch to latest
Ubuntu version and compilers.