### PR TITLE
pipe_observers: add const to the pipe write accessor

### DIFF
--- a/tests/pipe/pipe_observers.cpp
+++ b/tests/pipe/pipe_observers.cpp
@@ -42,7 +42,7 @@ auto get_##METHOD = [] (auto &a_queue, cl::sycl::pipe<char> &a_pipe) {  \
       /* Get write access to the pipe */                                \
       auto p = a_pipe.get_access<cl::sycl::access::mode::write>(cgh);   \
       /* Get write access to write back the value returned by the observer */ \
-      auto v = value.get_access<cl::sycl::access::mode::write>(cgh);    \
+      const auto v = value.get_access<cl::sycl::access::mode::write>(cgh);    \
                                                                         \
       cgh.single_task([=] {                                             \
           *v = p.METHOD();                                              \


### PR DESCRIPTION
This fixes:
ome/airlied/devel/compute/trisycl/tests/pipe/pipe_observers.cpp: In instantiation of ‘<lambda(auto:5&, cl::sycl::pipe&)> [with auto:5 = cl::sycl::queue]’:
/home/airlied/devel/compute/trisycl/tests/pipe/pipe_observers.cpp:69:3: required from here
/home/airlied/devel/compute/trisycl/tests/pipe/pipe_observers.cpp:48:11: error: passing ‘const cl::sycl::accessor<bool, 1, (cl::sycl::access::mode)43, (cl::sycl::access::target)2014>’ as ‘this’ argument discards qualifiers [-fpermissive]
v = p.METHOD();
^~
/home/airlied/devel/compute/trisycl/tests/pipe/pipe_observers.cpp:56:1: note: in expansion of macro ‘MAKE_GET_OBSERVER’
MAKE_GET_OBSERVER(empty, bool);
^~~~~~~~~~~~~~~~~
In file included from /home/airlied/devel/compute/trisycl/include/CL/sycl.hpp:37,
from /home/airlied/devel/compute/trisycl/tests/pipe/pipe_observers.cpp:5:
/home/airlied/devel/compute/trisycl/include/CL/sycl/accessor.hpp:294:39: note: in call to ‘typename cl::sycl::accessor<DataType, Dimensions, AccessMode, Target>::accessor_detail::reference cl::sycl::accessor<DataType, Dimensions, AccessMode, Target>::operator() [with DataType = bool; int Dimensions = 1; cl::sycl::access::mode AccessMode = (cl::sycl::access::mode)43; cl::sycl::access::target Target = (cl::sycl::access::target)2014; typename cl::sycl::accessor<DataType, Dimensions, AccessMode, Target>::accessor_detail::reference = bool&]’
typename accessor_detail::reference operator*() {

on Fedora 28/gcc8.1