### PR TITLE
types: fix non-opencl scalar types to not be vectors

### DIFF
--- a/include/CL/sycl/opencl_types.hpp
+++ b/include/CL/sycl/opencl_types.hpp
@@ -68,7 +68,10 @@ namespace sycl {
 */
 #define TRISYCL_DEFINE_TYPES(scalar, i)                                        \
   using TRISYCL_SIZED_NAME(TRISYCL_TYPE_CL_NAME(scalar), i) =                  \
-    BOOST_PP_CAT(TRISYCL_TYPE_NAME(scalar), i);
+    BOOST_PP_IF(                                                               \
+      BOOST_PP_EQUAL(i, 1),                                                    \
+      TRISYCL_TYPE_ACTUAL_NAME(scalar),                                        \
+      BOOST_PP_CAT(TRISYCL_TYPE_NAME(scalar), i));
 
 #else
 

--- a/tests/vector/cl_types.cpp
+++ b/tests/vector/cl_types.cpp
@@ -77,7 +77,10 @@ auto equal = [] (auto const &v, auto const &verif) {
   {                                                                            \
     std::initializer_list<TYPE> vil1 (VAL1);                                   \
     std::initializer_list<TYPE> vil2 (VAL2);                                   \
-    using v = SIZED_NAME(CL_TYPE, SIZE);                                       \
+    using v = BOOST_PP_IF(BOOST_PP_EQUAL(SIZE, 1),                             \
+                          BOOST_PP_CAT(cl::sycl::CL_TYPE, SIZE),               \
+                          BOOST_PP_CAT(                                        \
+                            BOOST_PP_CAT(cl::sycl::cl_, CL_TYPE), SIZE));      \
     using va_in = std::valarray<TYPE>;                                         \
     using va_out = std::valarray<OUT>;                                         \
     v v1 (VAL1);                                                               \
@@ -151,16 +154,16 @@ auto equal = [] (auto const &v, auto const &verif) {
   BOOST_PP_SEQ_FOR_EACH(GENERATE_TEST_SIZE, type, SIZES)
 
 #define ALL_TESTS                                                              \
-  GENERATE_TEST_TYPE((char,              cl_char,   0));                       \
-  GENERATE_TEST_TYPE((unsigned char,     cl_uchar,  0));                       \
-  GENERATE_TEST_TYPE((short,             cl_short,  0));                       \
-  GENERATE_TEST_TYPE((short int,         cl_ushort, 0));                       \
-  GENERATE_TEST_TYPE((int,               cl_int,    0));                       \
-  GENERATE_TEST_TYPE((unsigned int,      cl_uint,   0));                       \
-  GENERATE_TEST_TYPE((long,              cl_long,   0));                       \
-  GENERATE_TEST_TYPE((unsigned long int, cl_ulong,  0));                       \
-  GENERATE_TEST_TYPE((float,             cl_float,  1));                       \
-  GENERATE_TEST_TYPE((double,            cl_double, 1));
+  GENERATE_TEST_TYPE((char,              char,   0));                       \
+  GENERATE_TEST_TYPE((unsigned char,     uchar,  0));                       \
+  GENERATE_TEST_TYPE((short,             short,  0));                       \
+  GENERATE_TEST_TYPE((short int,         ushort, 0));                       \
+  GENERATE_TEST_TYPE((int,               int,    0));                       \
+  GENERATE_TEST_TYPE((unsigned int,      uint,   0));                       \
+  GENERATE_TEST_TYPE((long,              long,   0));                       \
+  GENERATE_TEST_TYPE((unsigned long int, ulong,  0));                       \
+  GENERATE_TEST_TYPE((float,             float,  1));                       \
+  GENERATE_TEST_TYPE((double,            double, 1));
 
 int test_main(int argc, char *argv[]) {
   constexpr size_t N = 16;


### PR DESCRIPTION
This is my first (maybe 20th I did locally) go at fixing the scalar types when we aren't using OPENCL.

When I moved some of the size_t to cl_ulong in the later patches, the local tests start failing (when built without OPENCL) because it couldn't cast vec<cl_ulong,1> to size_t when it really should have been cl_ulong to size_t.

The test fix is a little messier, but I ran into a lot of BOOST_PP problems with commas and didn't dig my way out for a few hours, this was the best compromise I came up with that built and passed the tests.

