### PR TITLE
group: rename get_linear->get_linear_id for SYCL 1.2.1 rev 3

### DIFF
--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -170,7 +170,7 @@ public:
   /** Get a linearized version of the group ID
 
    */
-  size_t get_linear() const {
+  size_t get_linear_id() const {
     return detail::linear_id(get_group_range(), get_id());
   }
 

--- a/tests/group/group.cpp
+++ b/tests/group/group.cpp
@@ -67,7 +67,7 @@ auto display_test = [](auto ndi) {
   DISPLAY_ELEMENTS(get_offset);
   ndi.get_id().display();
   DISPLAY_ELEMENTS(get_id);
-  std::cout << ndi.get_linear() << std::endl;
+  std::cout << ndi.get_linear_id() << std::endl;
 };
 
 int main() {


### PR DESCRIPTION
Just one that was missed in the last set of these by the looks of it.