### PR TITLE
buffer: fix get_access to correspond to spec.

### DIFF
--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -371,14 +371,10 @@ public:
 
       \todo More elegant solution
   */
-  template <access::mode Mode,
-            access::target Target = access::target::host_buffer>
-  accessor<T, Dimensions, Mode, Target>
+  template <access::mode Mode>
+  accessor<T, Dimensions, Mode, access::target::host_buffer>
   get_access() {
-    static_assert(Target == access::target::host_buffer,
-                  "get_access() without a command group handler is only"
-                  " for host_buffer accessor");
-    implementation->implementation->template track_access_mode<Mode, Target>();
+    implementation->implementation->template track_access_mode<Mode, access::target::host_buffer>();
     return { *this };
   }
 

--- a/tests/2014-04-21-HPC-GPU_Meetup/slide_26.cpp
+++ b/tests/2014-04-21-HPC-GPU_Meetup/slide_26.cpp
@@ -14,8 +14,7 @@ int my_array [20];
     // my_array is now taken over by the SYCL system and its contents undefined
 
     {
-        auto my_access = my_buffer.get_access<cl::sycl::access::mode::read_write,
-                                              cl::sycl::access::target::host_buffer> ();
+        auto my_access = my_buffer.get_access<cl::sycl::access::mode::read_write>();
         /* The host now has access to the buffer via my_access.
            This is a synchronizing operation - it blocks until access is ready.
            Access is released when my_access is destroyed

--- a/tests/accessor/accessor.cpp
+++ b/tests/accessor/accessor.cpp
@@ -25,12 +25,9 @@ int main() {
     cl::sycl::buffer<int, 3> c({ N, M, P });
 
     // Test from the host
-    auto A = a.get_access<cl::sycl::access::mode::read_write,
-                          cl::sycl::access::target::host_buffer>();
-    auto B = b.get_access<cl::sycl::access::mode::read_write,
-                          cl::sycl::access::target::host_buffer>();
-    auto C = c.get_access<cl::sycl::access::mode::read_write,
-                          cl::sycl::access::target::host_buffer>();
+    auto A = a.get_access<cl::sycl::access::mode::read_write>();
+    auto B = b.get_access<cl::sycl::access::mode::read_write>();
+    auto C = c.get_access<cl::sycl::access::mode::read_write>();
 
     // Test the STL-like accessor member types
     TEST_TYPE(A, value_type, int);

--- a/tests/accessor/accessor_sizes.cpp
+++ b/tests/accessor/accessor_sizes.cpp
@@ -22,18 +22,15 @@ using namespace cl::sycl;
 int test_main(int argc, char *argv[]) {
   range<1> r1 { 8 };
   buffer<double> b1 { r1 };
-  CHECK_RANGE_ACCESSOR(r1, (b1.get_access<access::mode::read_write,
-                                          access::target::host_buffer>()));
+  CHECK_RANGE_ACCESSOR(r1, (b1.get_access<access::mode::read_write>()));
 
   range<2> r2 { 3, 5 };
   buffer<short, 2> b2 { r2 };
-  CHECK_RANGE_ACCESSOR(r2, (b2.get_access<access::mode::read_write,
-                                          access::target::host_buffer>()));
+  CHECK_RANGE_ACCESSOR(r2, (b2.get_access<access::mode::read_write>()));
 
   range<3> r3 { 2, 7, 11 };
   buffer<short, 3> b3 { r3 };
-  CHECK_RANGE_ACCESSOR(r3, (b3.get_access<access::mode::read_write,
-                                          access::target::host_buffer>()));
+  CHECK_RANGE_ACCESSOR(r3, (b3.get_access<access::mode::read_write>()));
 
   return 0;
 }

--- a/tests/buffer/buffer_map_allocator.cpp
+++ b/tests/buffer/buffer_map_allocator.cpp
@@ -16,8 +16,7 @@ int test_main(int argc, char *argv[]) {
 
   buffer<int, 1, map_allocator<int>> buff { vect.data(), range<1> { size_t(N) } };
 
-  auto read = buff.get_access<access::mode::read,
-                              access::target::host_buffer>();
+  auto read = buff.get_access<access::mode::read>();
   for (auto i = 0; i < N; ++i) {
     // std::cerr << vect[i] << ':' << i << std::endl;
     // check that the buffer has been properly 're-initialized'

--- a/tests/buffer/buffer_set_final_data_1.cpp
+++ b/tests/buffer/buffer_set_final_data_1.cpp
@@ -77,8 +77,7 @@ int test_main(int argc, char *argv[]) {
 
     {
       buffer<int> buff { v.begin(), v.end() };
-      auto read = buff.get_access<access::mode::read,
-           access::target::host_buffer>();
+      auto read = buff.get_access<access::mode::read>();
       buff.set_final_data(w.begin());
     }
 
@@ -94,8 +93,7 @@ int test_main(int argc, char *argv[]) {
     {
       buffer<int> buff { v.begin(), v.end() };
       buff.set_final_data(v.begin());
-      auto write = buff.get_access<access::mode::write,
-           access::target::host_buffer>();
+      auto write = buff.get_access<access::mode::write>();
       for (int i = 0; i < N; ++i)
         write[i] = i;
     }
@@ -111,8 +109,7 @@ int test_main(int argc, char *argv[]) {
 
     {
       buffer<int> buff { v.cbegin(), v.cend() };
-      auto write = buff.get_access<access::mode::write,
-           access::target::host_buffer>();
+      auto write = buff.get_access<access::mode::write>();
       for (int i = 0; i < N; ++i)
         write[i] = i;
     }

--- a/tests/buffer/buffer_unique_ptr.cpp
+++ b/tests/buffer/buffer_unique_ptr.cpp
@@ -51,7 +51,7 @@ int test_main(int argc, char *argv[]) {
                                      });
     });
 
-  auto result = b.get_access<access::mode::read, access::target::host_buffer>();
+  auto result = b.get_access<access::mode::read>();
   for (int i = 0; i != N; ++i) {
     //std::cerr << result[i] << ':' << i << std::endl;
     BOOST_CHECK(result[i] == 2*(314 + i));

--- a/tests/buffer/shared_buffer.cpp
+++ b/tests/buffer/shared_buffer.cpp
@@ -30,13 +30,13 @@ cl::sycl::buffer<int, 1> f(void) {
     DISPLAY_BUFFER_USE_COUNT(a);
     DISPLAY_BUFFER_USE_COUNT(b);
     DISPLAY_BUFFER_USE_COUNT(c);
-    auto B = b.get_access<access::mode::write, access::target::host_buffer>();
+    auto B = b.get_access<access::mode::write>();
 
     for (std::size_t i = 0; i != N; ++i)
       B[i] = i*56 - 100;
 
     // Check b & c storage is really shared
-    auto C = c.get_access<access::mode::read, access::target::host_buffer>();
+    auto C = c.get_access<access::mode::read>();
     DISPLAY_BUFFER_USE_COUNT(a);
     DISPLAY_BUFFER_USE_COUNT(b);
     DISPLAY_BUFFER_USE_COUNT(c);

--- a/tests/common/test-helpers.hpp
+++ b/tests/common/test-helpers.hpp
@@ -88,8 +88,7 @@ bool trisycl_verify_buffer_value(
   do {                                                                  \
     try {                                                               \
       trisycl_verify_buffer_value(b,                                    \
-                                  b.get_access<cl::sycl::access::mode::read, \
-                                  cl::sycl::access::target::host_buffer>(), \
+                                  b.get_access<cl::sycl::access::mode::read>(), \
                                   func);                                \
     }                                                                   \
     catch (std::runtime_error &e) {                                     \

--- a/tests/jacobi/jacobi2d-st-cplx-var.cpp
+++ b/tests/jacobi/jacobi2d-st-cplx-var.cpp
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
       float tmp = (float) (i*(j+2) + 10) / N;
       Complex value(tmp, tmp);
       cl::sycl::id<2> id = {i, j};
-      ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
-      ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
+      ioBuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
+      ioABuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
     }
   }
 

--- a/tests/jacobi/jacobi2d-st-fxd.cpp
+++ b/tests/jacobi/jacobi2d-st-fxd.cpp
@@ -29,8 +29,8 @@ int main(int argc, char **argv) {
     for (size_t j = 0; j < N; ++j){
       float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
-      ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
-      ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
+      ioBuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
+      ioABuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
 #if DEBUG_STENCIL
       a_test[i*N+j] = value;
       b_test[i*N+j] = value;
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 
 #if DEBUG_STENCIL
   // get the gpu result
-  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>();
+  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read>();
   ute_and_are(a_test,b_test,C);
 #endif
 

--- a/tests/jacobi/jacobi2d-st-gen-var.cpp
+++ b/tests/jacobi/jacobi2d-st-gen-var.cpp
@@ -40,8 +40,8 @@ int main(int argc, char **argv) {
     for (size_t j = 0; j < N; ++j){
       float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
-      ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
-      ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
+      ioBuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
+      ioABuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
 #if DEBUG_STENCIL
       a_test[i*N+j] = value;
       b_test[i*N+j] = value;
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
 
 #if DEBUG_STENCIL
   // get the gpu result
-  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>();
+  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read>();
   ute_and_are(a_test,b_test,C);
 #endif
 

--- a/tests/jacobi/jacobi2d-st-var.cpp
+++ b/tests/jacobi/jacobi2d-st-var.cpp
@@ -35,8 +35,8 @@ int main(int argc, char **argv) {
     for (size_t j = 0; j < N; ++j){
       float value = ((float) i*(j+2) + 10) / N;
       cl::sycl::id<2> id = {i, j};
-      ioBuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
-      ioABuffer.get_access<cl::sycl::access::mode::write, cl::sycl::access::target::host_buffer>()[id] = value;
+      ioBuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
+      ioABuffer.get_access<cl::sycl::access::mode::write>()[id] = value;
 #if DEBUG_STENCIL
       a_test[i*N+j] = value;
       b_test[i*N+j] = value;
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
 
 #if DEBUG_STENCIL
   // get the gpu result
-  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>();
+  auto C = (ioABuffer).get_access<cl::sycl::access::mode::read>();
   ute_and_are(a_test,b_test,C);
 #endif
 

--- a/tests/jacobi/jacobi2d-tile.cpp
+++ b/tests/jacobi/jacobi2d-tile.cpp
@@ -25,8 +25,8 @@ int main(int argc, char **argv) {
     for (size_t j = 0; j < N; ++j){
       float value = ((float) i*(j+2) + 10) / N;
       sycl::id<2> id = {i, j};
-      ioABuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
-      ioBBuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
+      ioABuffer.get_access<sycl::access::mode::write>()[id] = value;
+      ioBBuffer.get_access<sycl::access::mode::write>()[id] = value;
 #if DEBUG_STENCIL
       a_test[i*N+j] = value;
       b_test[i*N+j] = value;
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
 
 #if DEBUG_STENCIL
   // get the gpu result
-  auto C = ioABuffer.get_access<sycl::access::mode::read, sycl::access::target::host_buffer>();
+  auto C = ioABuffer.get_access<sycl::access::mode::read>();
   ute_and_are(a_test,b_test,C);
 #endif
 

--- a/tests/jacobi/jacobi2d.cpp
+++ b/tests/jacobi/jacobi2d.cpp
@@ -34,8 +34,8 @@ int main(int argc, char **argv)
         {
             float value = ((float)i*(j + 2) + 10) / N;
             sycl::id<2> id = { i, j };
-            ioABuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
-            ioBBuffer.get_access<sycl::access::mode::write, sycl::access::target::host_buffer>()[id] = value;
+            ioABuffer.get_access<sycl::access::mode::write>()[id] = value;
+            ioBBuffer.get_access<sycl::access::mode::write>()[id] = value;
 #if DEBUG_STENCIL
             a_test[i*N + j] = value;
             b_test[i*N + j] = value;
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
 
 #if DEBUG_STENCIL
   // get the gpu result
-  auto C = ioABuffer.get_access<sycl::access::mode::read, sycl::access::target::host_buffer>();
+  auto C = ioABuffer.get_access<sycl::access::mode::read>();
   ute_and_are(a_test,b_test,C);
 #endif
 


### PR DESCRIPTION
This must have changed in the spec, convert the constructor
to align with the spec to avoid the excess host_buffer.

This requires changes to a bunch of tests to align with the new API