### PR TITLE
address_space: realign with spec.

### DIFF
--- a/include/CL/sycl/address_space.hpp
+++ b/include/CL/sycl/address_space.hpp
@@ -138,13 +138,21 @@ using multi_ptr = detail::address_space_ptr<Pointer, AS>;
 
     \param pointer is the address with its address space to point to
 
-    \todo Implement the case with a plain pointer
 */
 template <typename T, access::address_space AS>
-multi_ptr<T, AS> make_multi(multi_ptr<T, AS> pointer) {
+multi_ptr<T, AS> make_ptr(multi_ptr<T, AS> pointer) {
   return pointer;
 }
 
+/** Construct a cl::sycl::multi_ptr<> with the right type
+
+    \todo Implement the case with a plain pointer
+*/
+template <typename T, access::address_space AS>
+multi_ptr<T, AS> make_ptr(T *pointer) {
+  detail::unimplemented();
+  return pointer;
+}
 }
 }
 /// @} End the parallelism Doxygen group

--- a/include/CL/sycl/address_space.hpp
+++ b/include/CL/sycl/address_space.hpp
@@ -23,15 +23,17 @@ namespace sycl {
     @{
 */
 
+namespace access {
 /** Enumerate the different OpenCL 2 address spaces */
-enum address_space {
-  constant_address_space,
-  generic_address_space,
-  global_address_space,
-  local_address_space,
-  private_address_space,
+enum class address_space {
+  global_space,
+  local_space,
+  constant_space,
+  private_space,
+  generic_space,
 };
 
+}
 }
 }
 /// @} End the address_spaces Doxygen group
@@ -52,7 +54,7 @@ namespace sycl {
     \param T is the type of the object
 */
 template <typename T>
-using constant = detail::addr_space<T, constant_address_space>;
+using constant = detail::addr_space<T, access::address_space::constant_space>;
 
 
 /** Declare a variable to be in the OpenCL constant address space
@@ -68,7 +70,7 @@ using constant_ptr = constant<T*>;
     \param T is the type of the object
 */
 template <typename T>
-using generic = detail::addr_space<T, generic_address_space>;
+using generic = detail::addr_space<T, access::address_space::generic_space>;
 
 
 /** Declare a variable to be in the OpenCL global address space
@@ -76,7 +78,7 @@ using generic = detail::addr_space<T, generic_address_space>;
     \param T is the type of the object
 */
 template <typename T>
-using global = detail::addr_space<T, global_address_space>;
+using global = detail::addr_space<T, access::address_space::global_space>;
 
 
 /** Declare a variable to be in the OpenCL global address space
@@ -93,7 +95,7 @@ using global_ptr = global<T*>;
     \param T is the type of the object
 */
 template <typename T>
-using local = detail::addr_space<T, local_address_space>;
+using local = detail::addr_space<T, access::address_space::local_space>;
 
 
 /** Declare a variable to be in the OpenCL local address space
@@ -109,7 +111,7 @@ using local_ptr = local<T*>;
     \param T is the type of the object
 */
 template <typename T>
-using priv = detail::addr_space<T, private_address_space>;
+using priv = detail::addr_space<T, access::address_space::private_space>;
 
 
 /** Declare a variable to be in the OpenCL private address space
@@ -128,7 +130,7 @@ using private_ptr = priv<T*>;
 
     Note that if \a Pointer is not a pointer type, it is an error.
 */
-template <typename Pointer, address_space AS>
+template <typename Pointer, access::address_space AS>
 using multi_ptr = detail::address_space_ptr<Pointer, AS>;
 
 
@@ -138,7 +140,7 @@ using multi_ptr = detail::address_space_ptr<Pointer, AS>;
 
     \todo Implement the case with a plain pointer
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 multi_ptr<T, AS> make_multi(multi_ptr<T, AS> pointer) {
   return pointer;
 }

--- a/include/CL/sycl/address_space/detail/address_space.hpp
+++ b/include/CL/sycl/address_space/detail/address_space.hpp
@@ -61,56 +61,56 @@ namespace detail {
     OpenCL device
 
     In the general case, do not add any OpenCL address space qualifier */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct ocl_type { // NOTE: renamed from opencl_type because of MSVC bug
   using type = T;
 };
 
 /// Add an attribute for __constant address space
 template <typename T>
-struct ocl_type<T, constant_address_space> {
+struct ocl_type<T, access::address_space::constant_space> {
   using type = TRISYCL_CONSTANT_AS T;
 };
 
 #if TRISYCL_CL_LANGUAGE_VERSION >= 200
 /// Add an attribute for __generic address space
 template <typename T>
-struct ocl_type<T, generic_address_space> {
+struct ocl_type<T, generic_space> {
   using type = TRISYCL_GENERIC_AS T;
 };
 #endif
 
 /// Add an attribute for __global address space
 template <typename T>
-struct ocl_type<T, global_address_space> {
+struct ocl_type<T, access::address_space::global_space> {
   using type = TRISYCL_GLOBAL_AS T;
 };
 
 /// Add an attribute for __local address space
 template <typename T>
-struct ocl_type<T, local_address_space> {
+struct ocl_type<T, access::address_space::local_space> {
   using type = TRISYCL_LOCAL_AS T;
 };
 
 /// Add an attribute for __private address space
 template <typename T>
-struct ocl_type<T, private_address_space> {
+struct ocl_type<T, access::address_space::private_space> {
   using type = TRISYCL_PRIVATE_AS T;
 };
 
 
 /* Forward declare some classes to allow some recursion in conversion
    operators */
-template <typename SomeType, address_space SomeAS>
+template <typename SomeType, access::address_space SomeAS>
 struct address_space_array;
 
-template <typename SomeType, address_space SomeAS>
+template <typename SomeType, access::address_space SomeAS>
 struct address_space_fundamental;
 
-template <typename SomeType, address_space SomeAS>
+template <typename SomeType, access::address_space SomeAS>
 struct address_space_object;
 
-template <typename SomeType, address_space SomeAS>
+template <typename SomeType, access::address_space SomeAS>
 struct address_space_ptr;
 
 /** Dispatch the address space implementation according to the requested type
@@ -120,7 +120,7 @@ struct address_space_ptr;
     \param AS is the address space to place the object into or to point to
     in the case of a pointer type
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 using addr_space =
   typename std::conditional<std::is_pointer<T>::value,
                             address_space_ptr<T, AS>,
@@ -141,7 +141,7 @@ using addr_space =
 
     \todo Verify/improve to deal with const/volatile?
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct address_space_base {
   /** Store the base type of the object
 
@@ -168,7 +168,7 @@ struct address_space_base {
 
     \param AS is the address space to place the object into
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct address_space_variable : public address_space_base<T, AS> {
   /** Store the base type of the object with OpenCL address space modifier
 
@@ -223,7 +223,7 @@ public:
 
     \todo Verify/improve to deal with const/volatile?
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct address_space_fundamental : public address_space_variable<T, AS> {
   /// Keep track of the base class as a short-cut
   using super = address_space_variable<T, AS>;
@@ -263,7 +263,7 @@ struct address_space_fundamental : public address_space_variable<T, AS> {
 
      Need to think further about it...
   */
-  template <typename SomeType, cl::sycl::address_space SomeAS>
+  template <typename SomeType, cl::sycl::access::address_space SomeAS>
   address_space_fundamental(address_space_fundamental<SomeType, SomeAS>& v)
   {
     /* Strangely I cannot have it working in the initializer instead, for
@@ -283,7 +283,7 @@ struct address_space_fundamental : public address_space_variable<T, AS> {
     All the address space pointers inherit from it, which makes trivial
     the implementation of \c cl::sycl::multi_ptr<T, AS>
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct address_space_ptr : public address_space_fundamental<T, AS> {
   // Verify that \a T is really a pointer
   static_assert(std::is_pointer<T>::value,
@@ -315,7 +315,7 @@ struct address_space_ptr : public address_space_fundamental<T, AS> {
 
     \param AS is the address space to place the object into
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 struct address_space_array : public address_space_variable<T, AS> {
   /// Keep track of the base class as a short-cut
   using super = address_space_variable<T, AS>;
@@ -355,7 +355,7 @@ struct address_space_array : public address_space_variable<T, AS> {
 
     \todo what about T having some final methods?
 */
-template <typename T, address_space AS>
+template <typename T, access::address_space AS>
 //struct address_space_object : public opencl_type<T, AS>::type,
 struct address_space_object : public ocl_type<T, AS>::type,
                               public address_space_base<T, AS> {

--- a/tests/address_spaces/address_spaces.cpp
+++ b/tests/address_spaces/address_spaces.cpp
@@ -86,9 +86,9 @@ int main() {
           global<unsigned long int *> g_p;
           // Can only point to a local<> object
           local<char *> l_p;
-          multi_ptr<char *, constant_address_space> c_mp = c_p;
+          multi_ptr<char *, access::address_space::constant_space> c_mp = c_p;
           c_mp--;
-          multi_ptr<double*, private_address_space> p_mp = pd;
+          multi_ptr<double*, access::address_space::private_space> p_mp = pd;
           auto ppd = make_multi(p_mp);
           *ppd = 5.5;
           auto p_c_p = make_multi(c_p);

--- a/tests/address_spaces/address_spaces.cpp
+++ b/tests/address_spaces/address_spaces.cpp
@@ -89,9 +89,9 @@ int main() {
           multi_ptr<char *, access::address_space::constant_space> c_mp = c_p;
           c_mp--;
           multi_ptr<double*, access::address_space::private_space> p_mp = pd;
-          auto ppd = make_multi(p_mp);
+          auto ppd = make_ptr(p_mp);
           *ppd = 5.5;
-          auto p_c_p = make_multi(c_p);
+          auto p_c_p = make_ptr(c_p);
           *ppd += *p_c_p;
 
           global<float> global_float;

--- a/tests/address_spaces/address_spaces_ptr.cpp
+++ b/tests/address_spaces/address_spaces_ptr.cpp
@@ -81,9 +81,9 @@ int main() {
           multi_ptr<char *, access::address_space::constant_space> c_mp = c_p;
           c_mp--;
           multi_ptr<double*, access::address_space::private_space> p_mp = pd;
-          auto ppd = make_multi(p_mp);
+          auto ppd = make_ptr(p_mp);
           *ppd = 5.5;
-          auto p_c_p = make_multi(c_p);
+          auto p_c_p = make_ptr(c_p);
           *ppd += *p_c_p;
 
         }

--- a/tests/address_spaces/address_spaces_ptr.cpp
+++ b/tests/address_spaces/address_spaces_ptr.cpp
@@ -78,9 +78,9 @@ int main() {
           global_ptr<unsigned long int> g_p;
           // Can only point to a local<> object
           local_ptr<char> l_p;
-          multi_ptr<char *, constant_address_space> c_mp = c_p;
+          multi_ptr<char *, access::address_space::constant_space> c_mp = c_p;
           c_mp--;
-          multi_ptr<double*, private_address_space> p_mp = pd;
+          multi_ptr<double*, access::address_space::private_space> p_mp = pd;
           auto ppd = make_multi(p_mp);
           *ppd = 5.5;
           auto p_c_p = make_multi(c_p);


### PR DESCRIPTION
This aligns the address space with the spec.

The 1.2.1 spec doesn't define generic at all, but I've left it
in for now.
