### PR TITLE
range: fix get_count->size rename.

### DIFF
--- a/include/CL/sycl/accessor/detail/local_accessor.hpp
+++ b/include/CL/sycl/accessor/detail/local_accessor.hpp
@@ -362,7 +362,7 @@ private:
 
   /// Allocate uninitialized buffer memory
   auto allocate_accessor(const range<Dimensions> &r) {
-    auto count = r.get_count();
+    auto count = r.size();
     // Allocate uninitialized memory
     allocation = std::allocator<value_type>{}.allocate(count);
     return boost::multi_array_ref<value_type, Dimensions> { allocation, r };

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -342,7 +342,7 @@ private:
 
   /// Allocate uninitialized buffer memory
   auto allocate_buffer(const range<Dimensions> &r) {
-    auto count = r.get_count();
+    auto count = r.size();
     // Allocate uninitialized memory
     allocation = alloc.allocate(count);
     return boost::multi_array_ref<value_type, Dimensions> { allocation, r };

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -45,12 +45,8 @@ public:
 
 
   /** Return the number of elements in the range
-
-      \todo Give back size() its real meaning in the specification
-
-      \todo add this method to the specification
-  */
-  size_t get_count() const {
+   */
+  size_t size() const {
     // Return the product of the sizes in each dimension
     return std::accumulate(this->cbegin(),
                            this->cend(),

--- a/tests/accessor/accessor_sizes.cpp
+++ b/tests/accessor/accessor_sizes.cpp
@@ -14,7 +14,7 @@ using namespace cl::sycl;
 
 #define CHECK_RANGE_ACCESSOR(r, a)                                \
   BOOST_CHECK(r  == a.get_range());                               \
-  BOOST_CHECK(r.get_count() == a.get_count());                    \
+  BOOST_CHECK(r.size() == a.get_count());                         \
   BOOST_CHECK(a.get_size()                                        \
               == a.get_count()*sizeof(decltype(a)::value_type));
 

--- a/tests/buffer/buffer_sizes.cpp
+++ b/tests/buffer/buffer_sizes.cpp
@@ -11,7 +11,7 @@ using namespace cl::sycl;
 
 #define CHECK_RANGE_BUFFER(r, b)                                  \
   BOOST_CHECK(r  == b.get_range());                               \
-  BOOST_CHECK(r.get_count() == b.get_count());                    \
+  BOOST_CHECK(r.size() == b.get_count());                         \
   BOOST_CHECK(b.get_size()                                        \
               == b.get_count()*sizeof(decltype(b)::value_type));
 

--- a/tests/range/range_size.cpp
+++ b/tests/range/range_size.cpp
@@ -10,24 +10,19 @@ using namespace cl::sycl;
 
 int test_main(int argc, char *argv[]) {
   range<1> r1 { 8 };
-  BOOST_CHECK(r1.size() == 1);
-  BOOST_CHECK(r1.get_count() == 8);
+  BOOST_CHECK(r1.size() == 8);
 
   range<2> r2 { 3, 5 };
-  BOOST_CHECK(r2.size() == 2);
-  BOOST_CHECK(r2.get_count() == 3*5);
+  BOOST_CHECK(r2.size() == 3*5);
 
   range<3> r3 { 2, 7, 11 };
-  BOOST_CHECK(r3.size() == 3);
-  BOOST_CHECK(r3.get_count() == 2*7*11);
+  BOOST_CHECK(r3.size() == 2*7*11);
 
   range<2> r2_double { 7 };
-  BOOST_CHECK(r2_double.size() == 2);
-  BOOST_CHECK(r2_double.get_count() == 7*7);
+  BOOST_CHECK(r2_double.size() == 7*7);
 
   range<3> r3_triple { 11 };
-  BOOST_CHECK(r3_triple.size() == 3);
-  BOOST_CHECK(r3_triple.get_count() == 11*11*11);
+  BOOST_CHECK(r3_triple.size() == 11*11*11);
 
   return 0;
 }


### PR DESCRIPTION
The spec seems to have fixed size to mean get_count, and there
is no get_count. Update the implementation/tests.