### PR TITLE
fix buffer release locking.

### DIFF
--- a/include/CL/sycl/buffer/detail/buffer_base.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_base.hpp
@@ -116,6 +116,7 @@ struct buffer_base : public std::enable_shared_from_this<buffer_base> {
 
   /// A task has released the buffer
   void release() {
+    std::lock_guard<std::mutex> lock(ready_mutex);
     if (--number_of_users == 0)
       // Notify the host consumers or the buffer destructor that it is ready
       ready.notify_all();


### PR DESCRIPTION
std::condition_variable requires the mutex be locked when
adjusting the variable even if the variable is atomic.

This should fix cases where the pipe_observers test would hang and stall CI.