### PR TITLE
Add missing group/item comparison operators

### DIFF
--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -39,7 +39,7 @@ void parallel_for_workitem_in_group(const group<Dimensions> &g,
 /** A group index used in a parallel_for_workitem to specify a work_group
  */
 template <int Dimensions>
-struct group {
+struct group : boost::equality_comparable<group<Dimensions>> {
   /// \todo add this Boost::multi_array or STL concept to the
   /// specification?
   static constexpr auto dimensionality = Dimensions;
@@ -182,6 +182,12 @@ public:
     detail::parallel_for_workitem_in_group(*this, f);
   }
 
+  /* Comparison operators for group object.
+   */
+  bool operator==(const group &groupB) const {
+    return (group_id == groupB.group_id &&
+	    ndr == groupB.ndr);
+  }
 };
 
 /// @} End the parallelism Doxygen group

--- a/include/CL/sycl/h_item.hpp
+++ b/include/CL/sycl/h_item.hpp
@@ -40,7 +40,7 @@ namespace sycl {
     are passed by the runtime to each instance of the function object.
 */
 template <int Dimensions = 1>
-struct h_item {
+struct h_item : boost::equality_comparable<h_item<Dimensions>> {
   /// \todo add this Boost::multi_array or STL concept to the
   /// specification?
   static constexpr auto dimensionality = Dimensions;
@@ -228,6 +228,11 @@ public:
   // For the triSYCL implementation, need to set the global index
   void set_global(id<Dimensions> Index) { global_index = Index; }
 
+  /// comparison operators
+  bool operator==(const h_item<Dimensions> &itemB) const {
+    return (ND_range == itemB.ND_range &&
+            global_index == itemB.global_index);
+  }
 };
 
 /// @} End the parallelism Doxygen group

--- a/include/CL/sycl/item.hpp
+++ b/include/CL/sycl/item.hpp
@@ -26,7 +26,7 @@ namespace sycl {
     such as the definition range and offset.
 */
 template <int Dimensions = 1>
-class item {
+class item : boost::equality_comparable<item<Dimensions>> {
 
 public:
 
@@ -120,6 +120,12 @@ public:
     offset.display();
   }
 
+  /// Comparison operators for item
+  bool operator==(const item<Dimensions> &itemB) const {
+    return (global_range == itemB.global_range &&
+            global_index == itemB.global_index &&
+            offset == itemB.offset);
+  }
 };
 
 /// @} End the parallelism Doxygen group

--- a/include/CL/sycl/nd_item.hpp
+++ b/include/CL/sycl/nd_item.hpp
@@ -25,12 +25,11 @@ namespace sycl {
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
 */
-
 /** A SYCL nd_item stores information on a work-item within a work-group,
     with some more context such as the definition ranges.
 */
 template <int Dimensions = 1>
-struct nd_item {
+struct nd_item : boost::equality_comparable<nd_item<Dimensions>> {
   /// \todo add this Boost::multi_array or STL concept to the
   /// specification?
   static constexpr auto dimensionality = Dimensions;
@@ -222,6 +221,11 @@ public:
   // For the triSYCL implementation, need to set the global index
   void set_global(id<Dimensions> Index) { global_index = Index; }
 
+  // Comparison operators
+  bool operator==(const nd_item<Dimensions> &nd_itemB) const {
+    return (ND_range == nd_itemB.ND_range &&
+	    global_index == nd_itemB.global_index);
+  }
 };
 
 /// @} End the parallelism Doxygen group

--- a/include/CL/sycl/nd_range.hpp
+++ b/include/CL/sycl/nd_range.hpp
@@ -30,7 +30,7 @@ namespace sycl {
     \todo add copy constructors in the specification
 */
 template <int Dimensions = 1>
-struct nd_range {
+struct nd_range : boost::equality_comparable<nd_range<Dimensions>> {
   /// \todo add this Boost::multi_array or STL concept to the
   /// specification?
   static constexpr auto dimensionality = Dimensions;
@@ -83,6 +83,11 @@ public:
     offset.display();
   }
 
+  /// Comparison operators for nd_range.
+  bool operator==(const nd_range &nd_rangeB) const {
+    return (global_range == nd_rangeB.global_range &&
+	    offset == nd_rangeB.offset);
+  }
 };
 
 /// @} End the parallelism Doxygen group

--- a/tests/group/CMakeLists.txt
+++ b/tests/group/CMakeLists.txt
@@ -43,4 +43,10 @@ declare_trisycl_test(TARGET group TEST_REGEX
 1 2 3 
  4 2 1
 4 2 1 
-29")
+29
+1
+0
+0
+1
+0
+1")

--- a/tests/group/group.cpp
+++ b/tests/group/group.cpp
@@ -41,6 +41,12 @@
    CHECK: 4 2 1
    CHECK: 4 2 1
    CHECK: 29
+   CHECK: 1
+   CHECK: 0
+   CHECK: 0
+   CHECK: 1
+   CHECK: 0
+   CHECK: 1
 */
 
 #include <CL/sycl.hpp>
@@ -80,5 +86,16 @@ int main() {
   group<3> i3 { {4, 2, 1 }, { { 10, 9, 12 }, { 2, 3, 6 }, { 1, 2, 3 } } };
   display_test(i3);
 
+  group<> g2 { 3, { 10, 2 }};
+  std::cout << (g == g2) << std::endl;
+  std::cout << (g != g2) << std::endl;
+
+  group<> g3 { 3, { 11, 2 }};
+  std::cout << (g == g3) << std::endl;
+  std::cout << (g != g3) << std::endl;
+
+  group<> g4 { 4, { 10, 2 }};
+  std::cout << (g == g4) << std::endl;
+  std::cout << (g != g4) << std::endl;
   return 0;
 }

--- a/tests/item/CMakeLists.txt
+++ b/tests/item/CMakeLists.txt
@@ -13,4 +13,8 @@ declare_trisycl_test(TARGET item TEST_REGEX
  100 10
  2 3
  0 0
-302")
+302
+1
+0
+0
+1")

--- a/tests/item/item.cpp
+++ b/tests/item/item.cpp
@@ -11,6 +11,10 @@
    CHECK: 2 3
    CHECK: 0 0
    CHECK: 302
+   CHECK: 1
+   CHECK: 0
+   CHECK: 0
+   CHECK: 1
 */
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -36,5 +40,12 @@ int main() {
   i2.get_offset().display();
   std::cout << i2.get_linear_id() << std::endl;
 
+  item<> ic { 7, 3, 2 };
+  std::cout << (i == ic) << std::endl;
+  std::cout << (i != ic) << std::endl;
+
+  item<> inc { 8, 3, 2 };
+  std::cout << (i == inc) << std::endl;
+  std::cout << (i != inc) << std::endl;
   return 0;
 }

--- a/tests/nd_item/CMakeLists.txt
+++ b/tests/nd_item/CMakeLists.txt
@@ -52,4 +52,10 @@ declare_trisycl_test(TARGET nd_item TEST_REGEX
 4 2 1 
 29
  5 3 2
-5 3 2 ")
+5 3 2 
+1
+0
+0
+1
+1
+0")

--- a/tests/nd_item/nd_item.cpp
+++ b/tests/nd_item/nd_item.cpp
@@ -50,6 +50,12 @@
    CHECK: 29
    CHECK: 5 3 2
    CHECK: 5 3 2
+   CHECK: 1
+   CHECK: 0
+   CHECK: 0
+   CHECK: 1
+   CHECK: 1
+   CHECK: 0
 */
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -91,5 +97,16 @@ int main() {
   nd_item<3> i3 { {9, 8, 11 }, { { 10, 9, 12 }, { 2, 3, 6 }, { 1, 2, 3 } } };
   display_test(i3);
 
+  nd_item<> ic { 7, { 10, 5 } };
+  std::cout << (i == ic) << std::endl;
+  std::cout << (i != ic) << std::endl;
+
+  nd_item<> inc1 { 8, { 10, 5 } };
+  std::cout << (i == inc1) << std::endl;
+  std::cout << (i != inc1) << std::endl;
+
+  nd_item<> inc2 { 7, { 10, 8 } };
+  std::cout << (i == inc2) << std::endl;
+  std::cout << (i != inc2) << std::endl;
   return 0;
 }

--- a/tests/nd_range/CMakeLists.txt
+++ b/tests/nd_range/CMakeLists.txt
@@ -18,5 +18,9 @@ declare_trisycl_test(TARGET nd_range TEST_REGEX
  0 0
  1
  6 4
- 6 5")
- 
+ 6 5 7
+1
+0
+0
+1")
+

--- a/tests/nd_range/nd_range.cpp
+++ b/tests/nd_range/nd_range.cpp
@@ -16,6 +16,10 @@
    CHECK-NEXT: 1
    CHECK-NEXT: 6 4
    CHECK-NEXT: 6 5 7
+   CHECK-NEXT: 1
+   CHECK-NEXT: 0
+   CHECK-NEXT: 0
+   CHECK-NEXT: 1
 */
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -63,5 +67,12 @@ int main() {
   nd_range<3> ndri3 { { 11, 25, 48 }, { 2, 5, 7 } };
   ndri3.get_group_range().display();
 
+  nd_range<> ndric { 1, 2, 3 };
+  std::cout << (ndri1 == ndric) << std::endl;
+  std::cout << (ndri1 != ndric) << std::endl;
+
+  nd_range<> ndrinc { 1, 2, 5 };
+  std::cout << (ndri1 == ndrinc) << std::endl;
+  std::cout << (ndri1 != ndrinc) << std::endl;
   return 0;
 }


### PR DESCRIPTION
These are all defined in the spec, so add == and != for
nd_range, group, item, nd_item and h_item.

This is based on the id operators #177 so should be applied after that one is sorted out.