### PR TITLE
 Add a missing lock around the use of a std::condition_variable

### DIFF
--- a/include/CL/sycl/queue/detail/queue.hpp
+++ b/include/CL/sycl/queue/detail/queue.hpp
@@ -65,7 +65,11 @@ struct queue : detail::debug<detail::queue> {
   /// Signal that a new kernel finished on this queue
   void kernel_end() {
     TRISYCL_DUMP_T("A kernel of the queue ended");
+    std::unique_lock<std::mutex> ul { finished_mutex };
     if (--running_kernels == 0) {
+      // Micro-optimization: unlock before the notification
+      // https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all
+      ul.unlock();
       /* It was the last kernel running, so signal the queue just in
          case it was working for it for completion
 


### PR DESCRIPTION
Also apply some micro-optimization to unlock before std::condition_variable::notify_all().

This should close https://github.com/triSYCL/triSYCL/issues/37