### PR TITLE
Link to Boost::filesystem

### DIFF
--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -215,7 +215,8 @@ function(add_sycl_to_target targetName)
     $<$<BOOL:${TRISYCL_OPENCL}>:${OpenCL_LIBRARIES}>
     Threads::Threads
     $<$<BOOL:${LOG_NEEDED}>:Boost::log>
-    Boost::chrono)
+    Boost::chrono
+    Boost::filesystem)
 
   # Compile definitions
   target_compile_definitions(${targetName} PUBLIC

--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -167,7 +167,11 @@ if(TRISYCL_OPENMP)
 endif()
 
 # Find Boost
-find_package(Boost 1.58 REQUIRED COMPONENTS chrono log)
+set(BOOST_REQUIRED_COMPONENTS chrono log)
+if(TRISYCL_OPENCL)
+  list(APPEND BOOST_REQUIRED_COMPONENTS filesystem)
+endif()
+find_package(Boost 1.58 REQUIRED COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 # If debug or trace we need boost log
 if(TRISYCL_DEBUG OR TRISYCL_DEBUG_STRUCTORS OR TRISYCL_TRACE_KERNEL)

--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -216,7 +216,7 @@ function(add_sycl_to_target targetName)
     Threads::Threads
     $<$<BOOL:${LOG_NEEDED}>:Boost::log>
     Boost::chrono
-    Boost::filesystem)
+    $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem>) #Required by BOOST_COMPUTE_USE_OFFLINE_CACHE.
 
   # Compile definitions
   target_compile_definitions(${targetName} PUBLIC


### PR DESCRIPTION
Boost::compute depends on Boost::filesystem when compiling with its offline cache, according to [the documentation](https://boostorg.github.io/compute/boost_compute/getting_started.html). We must also link Boost::filesystem in order to compile a project with TriSYCL.

This fixes one of the two errors reported in #201. This can be seen to go wrong by compiling TriSYCL itself, where it goes wrong in some of the tests.