### PR TITLE
Link OpenMP on Windows

### DIFF
--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -232,11 +232,10 @@ function(add_sycl_to_target targetName)
     ${TRISYCL_COMPILE_OPTIONS}
     $<$<BOOL:${TRISYCL_OPENMP}>:${OpenMP_CXX_FLAGS}>)
 
-  if(${TRISYCL_OPENMP} AND (NOT WIN32))
-    # Does not support generator expressions
+  if(${TRISYCL_OPENMP})
     set_target_properties(${targetName}
       PROPERTIES
       LINK_FLAGS ${OpenMP_CXX_FLAGS})
-  endif(${TRISYCL_OPENMP} AND (NOT WIN32))
+  endif(${TRISYCL_OPENMP})
 
 endfunction(add_sycl_to_target)


### PR DESCRIPTION
This has been disabled since the first CMake scripts in commit 7d6b30d74cfed2ef0a6e0bf1a9c90539cbe83b93.

Trying to compile anything using TriSYCL on Windows with OpenMP enabled causes a linker error. Removing this check causes it to link properly.

I believe we have two options to fix it: Either cause OpenMP on Windows to always fail in CMake's configure stage, or link it properly. This implements the second option! If there were good reasons to not link OpenMP on Windows, then we could also implement the former.

Fixes one of the two errors outlined in #201.