### PR TITLE
Fix naming conflict with windef.h

### DIFF
--- a/tests/array_partition/array_partition.cpp
+++ b/tests/array_partition/array_partition.cpp
@@ -16,13 +16,13 @@
 using namespace cl::sycl;
 using namespace cl::sycl::vendor;
 
-constexpr size_t SIZE = 4;
+constexpr size_t ARRAY_LENGTH = 4;
 
 using Type = int;
 
 #define TRISYCL_CHECK(ARRAY, PARTITION_TYPE, EXPECTED_VALUE)            \
   {                                                                     \
-    std::array<Type, SIZE> expected_value EXPECTED_VALUE;               \
+    std::array<Type, ARRAY_LENGTH> expected_value EXPECTED_VALUE;       \
     BOOST_CHECK(decltype(ARRAY)::partition_type == PARTITION_TYPE);     \
     /* Evaluate size */                                                 \
     BOOST_CHECK(ARRAY.size() == expected_value.size());                 \
@@ -36,30 +36,30 @@ using Type = int;
 
 int test_main(int argc, char *argv[]) {
   // Construct a partition_array from a list of number
-  xilinx::partition_array<Type, SIZE> A = {1, 2, 3, 4};
+  xilinx::partition_array<Type, ARRAY_LENGTH> A = {1, 2, 3, 4};
   TRISYCL_CHECK(A, xilinx::partition::type::none, ({1, 2, 3, 4}))
 
   // Construct a partition_array from another partition_array of the same size
-  xilinx::partition_array<Type, SIZE> B { A };
+  xilinx::partition_array<Type, ARRAY_LENGTH> B { A };
   TRISYCL_CHECK(B, xilinx::partition::type::none, ({1, 2, 3, 4}));
 
   // Construct a partition_array from a std::array
-  std::array<Type, SIZE> toC = {5, 6, 7, 8};
-  xilinx::partition_array<Type, SIZE> C { toC };
+  std::array<Type, ARRAY_LENGTH> toC = {5, 6, 7, 8};
+  xilinx::partition_array<Type, ARRAY_LENGTH> C { toC };
   TRISYCL_CHECK(C, xilinx::partition::type::none, ({5, 6, 7, 8}));
 
   // Construct a partition_array by default
-  xilinx::partition_array<Type, SIZE> D;
+  xilinx::partition_array<Type, ARRAY_LENGTH> D;
   D = B;
   TRISYCL_CHECK(D, xilinx::partition::type::none, ({1, 2, 3, 4}));
 
   // Cyclic Partition for E
-  xilinx::partition_array<Type, SIZE,
-                          xilinx::partition::cyclic<SIZE>> E = {1, 2, 3, 4};
+  xilinx::partition_array<Type, ARRAY_LENGTH,
+                          xilinx::partition::cyclic<ARRAY_LENGTH>> E = {1, 2, 3, 4};
   TRISYCL_CHECK(E, xilinx::partition::type::cyclic, ({1, 2, 3, 4}));
 
-  xilinx::partition_array<Type, SIZE,
-                          xilinx::partition::cyclic<SIZE>> F { E };
+  xilinx::partition_array<Type, ARRAY_LENGTH,
+                          xilinx::partition::cyclic<ARRAY_LENGTH>> F { E };
   TRISYCL_CHECK(F, xilinx::partition::type::cyclic, ({1, 2, 3, 4}));
 
   F = C;
@@ -67,12 +67,12 @@ int test_main(int argc, char *argv[]) {
   TRISYCL_CHECK(F, xilinx::partition::type::cyclic, ({5, 6, 7, 8}));
 
   // Block Partition for G
-  xilinx::partition_array<Type, SIZE,
-                          xilinx::partition::block<SIZE>> G = F;
+  xilinx::partition_array<Type, ARRAY_LENGTH,
+                          xilinx::partition::block<ARRAY_LENGTH>> G = F;
   TRISYCL_CHECK(G, xilinx::partition::type::block, ({5, 6, 7, 8}));
 
   // Block Partition for H
-  xilinx::partition_array<Type, SIZE,
+  xilinx::partition_array<Type, ARRAY_LENGTH,
                           xilinx::partition::complete<>> H;
   H = toC;
   TRISYCL_CHECK(H, xilinx::partition::type::complete, ({5, 6, 7, 8}));


### PR DESCRIPTION
`windef.h` defines a symbol called SIZE in the global namespace, which conflicts with the definition here and causes a compile error. `windef.h` has no business defining that common a name in the global namespace, but we'll have to live with it and adjust our code around it.

Before this fix, compiling the tests on Windows using MinGW would result in the following error:

    [ 17%] Building CXX object tests/array_partition/CMakeFiles/array_partition_array_partition.dir/array_partition.cpp.obj
    C:\Persoonlijk\Projecten\Libraries\triSYCL\tests\array_partition\array_partition.cpp:19:18: error: 'constexpr const size_t SIZE' redeclared as different kind of symbol
     constexpr size_t SIZE = 4;
                      ^~~~
    In file included from C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/x86_64-w64-mingw32/include/windows.h:69,
                     from C:/PROGRA~1/Boost/include/BOOST-~1/boost/test/impl/debug.ipp:32,
                     from C:/PROGRA~1/Boost/include/BOOST-~1/boost/test/minimal.hpp:54,
                     from C:\Persoonlijk\Projecten\Libraries\triSYCL\tests\array_partition\array_partition.cpp:12:
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/x86_64-w64-mingw32/include/windef.h:103:3: note: previous declaration 'typedef struct tagSIZE SIZE'
     } SIZE,*PSIZE,*LPSIZE;
       ^~~~

Renaming `SIZE` to `ARRAY_LENGTH` fixes this issue.