### PR TITLE
Removal of buffer::set_final_data(shared_ptr_class<T> finalData): iss…

### DIFF
--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -462,23 +462,7 @@ public:
       It is defined as a weak_ptr referring to a shared_ptr that is not
       associated with the cl::sycl::buffer, and so the cl::sycl::buffer
       will have no ownership of finalData.
-
-      \todo Update the API to take finalData by value instead of by
-            reference.  This way we can have an implicit conversion
-            possible at the API call from a shared_ptr<>, avoiding an
-            explicit weak_ptr<> creation
-
-      \todo figure out how set_final_data() interact with the other
-      way to write back some data or with some data sharing with the
-      host that can not be undone
   */
-  void set_final_data(shared_ptr_class<T> finalData) {
-    implementation->implementation->set_final_data(std::move(finalData));
-  }
-
-
-  /** Set destination of buffer data on destruction.
-   */
   void set_final_data(weak_ptr_class<T> finalData) {
     implementation->implementation->set_final_data(std::move(finalData));
   }
@@ -512,7 +496,9 @@ public:
       iterator will be alive after buffer destruction, otherwise the behaviour
       is undefined.
    */
-  template<typename Iterator>
+  template <typename Iterator,
+            typename ValueType =
+            typename std::iterator_traits<Iterator>::value_type>
   void set_final_data(Iterator&& finalData) {
     implementation->implementation->
       set_final_data(std::forward<Iterator>(finalData));

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -306,16 +306,6 @@ public:
   }
 
 
-  /** Provide destination for write-back on buffer destruction as a
-      shared pointer.
-   */
-  void set_final_data(std::shared_ptr<T> && final_data) {
-    final_write_back = [=] {
-      std::copy_n(access.data(), access.num_elements(), final_data.get());
-    };
-  }
-
-
   /** Disable write-back on buffer destruction as an iterator.
   */
   void set_final_data(std::nullptr_t) {
@@ -326,7 +316,9 @@ public:
   /** Provide destination for write-back on buffer destruction as an
       iterator
   */
-  template <typename Iterator>
+  template <typename Iterator,
+            typename ValueType =
+            typename std::iterator_traits<Iterator>::value_type>
   void set_final_data(Iterator final_data) {
  /*   using type_ = typename iterator_value_type<Iterator>::value_type;
     static_assert(std::is_same<type_, T>::value, "buffer type mismatch");


### PR DESCRIPTION
…ue #18

I removed the set_final_data functions related to the 
shared_ptr_class/shared_ptr. However, to keep the implicit casting from 
shared_ptr to weak_ptr I had to make the set_final_data call for 
Iterators more specific using the std::iterator_traits class (the same 
method is used on line 271 of SYCL/buffer.hpp). Otherwise invocations 
using shared_ptr's would fall into the too generic Iterator call and 
cause a compile error (no iterator trait members). 

The issue link: https://github.com/triSYCL/triSYCL/issues/18