### PR TITLE
Remove limitation on number of programs managed by triSYCL

### DIFF
--- a/include/CL/sycl/detail/global_config.hpp
+++ b/include/CL/sycl/detail/global_config.hpp
@@ -41,10 +41,6 @@
 */
 #ifdef TRISYCL_OPENCL
 
-/* There is a bug in Xilinx OpenCL runtime where the cl_kernel does
-   not keep alive its own cl_program */
-#define SDX_KERNEL_PROGRAM_OWNING_BUG
-
 // SYCL interoperation API with OpenCL requires some OpenCL C types:
 #if defined(__APPLE__)
 #include <OpenCL/cl.h>

--- a/include/CL/sycl/device_runtime.hpp
+++ b/include/CL/sycl/device_runtime.hpp
@@ -209,13 +209,7 @@ set_kernel(detail::task &task,
 #ifdef TRISYCL_OPENCL
   auto context = task.get_queue()->get_boost_compute().get_context();
   // Construct an OpenCL program from the precompiled kernel file
-  auto
-#ifdef SDX_KERNEL_PROGRAM_OWNING_BUG
-    /* There is a bug in Xilinx OpenCL runtime where the cl_kernel
-       does not keep alive its own cl_program */
-    static
-#endif
-    program = boost::compute::program::create_with_binary
+  auto program = boost::compute::program::create_with_binary
     (code::program::p->binary,
      code::program::p->binary_size,
      context);


### PR DESCRIPTION
Removing the static storage for cl_programs when compiling using SDx for 
the Xilinx runtime.

This relates to issue 145: https://github.com/triSYCL/triSYCL/issues/145