### PR TITLE
Refactored `parallel_for_workitem()` implementation

### DIFF
--- a/tests/parallel_for/CMakeLists.txt
+++ b/tests/parallel_for/CMakeLists.txt
@@ -2,48 +2,8 @@ cmake_minimum_required (VERSION 3.0) # The minimum version of CMake necessary to
 project (parallel_for) # The name of our project
 
 declare_trisycl_test(TARGET capture_scalars)
-declare_trisycl_test(TARGET hierarchical_new FORCE_SYNCRONOUS_EXEC TEST_REGEX
-"Group id = 0
-Local id = 0 \\(global id = 0\\)
-Local id = 1 \\(global id = 1\\)
-Global id = 0
-Global id = 1
-Group id = 1
-Local id = 0 \\(global id = 2\\)
-Local id = 1 \\(global id = 3\\)
-Global id = 2
-Global id = 3
-Group id = 2
-Local id = 0 \\(global id = 4\\)
-Local id = 1 \\(global id = 5\\)
-Global id = 4
-Global id = 5
-Group id = 3
-Local id = 0 \\(global id = 6\\)
-Local id = 1 \\(global id = 7\\)
-Global id = 6
-Global id = 7
-Group id = 4
-Local id = 0 \\(global id = 8\\)
-Local id = 1 \\(global id = 9\\)
-Global id = 8
-Global id = 9")
-declare_trisycl_test(TARGET hierarchical FORCE_SYNCRONOUS_EXEC TEST_REGEX
-"Group id = 0
-Local id = 0 \\(global id = 0\\)
-Local id = 1 \\(global id = 1\\)
-Group id = 1
-Local id = 0 \\(global id = 2\\)
-Local id = 1 \\(global id = 3\\)
-Group id = 2
-Local id = 0 \\(global id = 4\\)
-Local id = 1 \\(global id = 5\\)
-Group id = 3
-Local id = 0 \\(global id = 6\\)
-Local id = 1 \\(global id = 7\\)
-Group id = 4
-Local id = 0 \\(global id = 8\\)
-Local id = 1 \\(global id = 9\\)")
+declare_trisycl_test(TARGET hierarchical_new)
+declare_trisycl_test(TARGET hierarchical)
 declare_trisycl_test(TARGET initializer_list)
 declare_trisycl_test(TARGET item_no_offset)
 declare_trisycl_test(TARGET item)

--- a/tests/parallel_for/hierarchical.cpp
+++ b/tests/parallel_for/hierarchical.cpp
@@ -1,66 +1,80 @@
-/* RUN: %{execute}%s | %{filecheck} %s
-   CHECK: Group id = 0
-   CHECK: Local id = 0 (global id = 0)
-   CHECK: Local id = 1 (global id = 1)
-   CHECK: Group id = 1
-   CHECK: Local id = 0 (global id = 2)
-   CHECK: Local id = 1 (global id = 3)
-   CHECK: Group id = 2
-   CHECK: Local id = 0 (global id = 4)
-   CHECK: Local id = 1 (global id = 5)
-   CHECK: Group id = 3
-   CHECK: Local id = 0 (global id = 6)
-   CHECK: Local id = 1 (global id = 7)
-   CHECK: Group id = 4
-   CHECK: Local id = 0 (global id = 8)
-   CHECK: Local id = 1 (global id = 9)
-*/
+/* RUN: %{execute}%s
+ */
 
-/* The OpenMP based barrier use nested parallelism that makes order of
-   execution in parallel_for_workitem non deterministic so disable it on
-   this test
-*/
 #define TRISYCL_NO_BARRIER
 
-
-#include <vector>
 #include <CL/sycl.hpp>
+
+#include <boost/test/minimal.hpp>
 
 using namespace cl::sycl;
 
-int main() {
+template <int Dimensions, class kernel_name>
+void generic_par_for_wg(range<Dimensions> k_range,
+                        range<Dimensions> workgroup_size) {
   queue my_queue;
-  const int size = 10;
-  std::vector<int> data(size);
-  const int groupsize = 2;
-/* Put &data[0] instead of data.data() because it is not obvious in the
-   excerpt below it is a vector */
-//////// Start slide
-buffer<int> input(&data[0], size);
-buffer<int> output(size);
-my_queue.submit([&](handler &cgh)
-{
-  auto in_access = input.get_access<access::mode::read>(cgh);
-  auto out_access = output.get_access<access::mode::write>(cgh);
 
-  cgh.parallel_for_work_group<class hierarchical>(nd_range<>(range<>(size),
-                                                             range<>(groupsize)),
-                                                  [=](group<> group)
-  {
-    std::cout << "Group id = " << group.get_id(0) << std::endl;
+  // the product of all Dimensions e.g. 10*10*10 for {10,10,10}
+  auto linr_size = k_range.size(), linwg_size = workgroup_size.size();
 
-    group.parallel_for_work_item([=](h_item<1> tile)
-    {
-      std::cout << "Local id = " << tile.get_local_id(0)
-                << " (global id = " << tile.get_global_id(0) << ")" << std::endl;
-      out_access[tile.get_global_id()] = in_access[tile.get_global_id()] * 2;
-    });
+  // these will simply have the group, local and global linear ids assigned to
+  // them
+  auto group_lin = buffer<int>(linr_size / linwg_size);
+  auto loc_lin = buffer<int>(linr_size);
+  auto gl_lin = buffer<int>(linr_size);
+
+  my_queue.submit([&](handler &cgh) {
+    auto group_lin_acc = group_lin.get_access<access::mode::write>(cgh);
+    auto loc_lin_acc = loc_lin.get_access<access::mode::write>(cgh);
+    auto gl_lin_acc = gl_lin.get_access<access::mode::read_write>(cgh);
+
+    cgh.parallel_for_work_group<kernel_name>(
+        nd_range<Dimensions>(k_range, workgroup_size),
+        [=](group<Dimensions> group) {
+          group_lin_acc[group.get_linear_id()] = group.get_linear_id();
+
+          group.parallel_for_work_item([=](h_item<Dimensions> tile) {
+            loc_lin_acc[tile.get_global_linear_id()] =
+                tile.get_local_linear_id();
+            gl_lin_acc[tile.get_global_linear_id()] =
+                tile.get_global_linear_id();
+          });
+        });
   });
-});
-//////// End slide
+
+  auto loc_lin_out = loc_lin.get_access<access::mode::read>();
+  auto group_lin_out = group_lin.get_access<access::mode::read>();
+  auto gl_lin_out = gl_lin.get_access<access::mode::read>();
+
+  for (int i = 0; i < linr_size / linwg_size; ++i) {
+    BOOST_CHECK(group_lin_out[i] == i); // group id
+  }
+
+  for (int i = 0; i < linr_size; ++i) {
+    BOOST_CHECK(gl_lin_out[i] == i);                            // w1 global id
+    BOOST_CHECK(loc_lin_out[i] == loc_lin_out[i] % linwg_size); // local id
+  }
+
   /* We must wait for for the queue to finish as none of buffer's destruction
      is blocking.
    */
   my_queue.wait();
+}
+
+int test_main(int argc, char *argv[]) {
+  generic_par_for_wg<1, class par_1d>({10}, {2});
+  generic_par_for_wg<2, class par_2d_square>({10, 10}, {2, 2});
+  generic_par_for_wg<2, class par_2d_square>({12, 12}, {4, 4});
+  generic_par_for_wg<2, class par_2d_rect>({12, 6}, {4, 2});
+  generic_par_for_wg<3, class par_3d_square>({10, 10, 10}, {2, 2, 2});
+  generic_par_for_wg<3, class par_3d_rect>({12, 8, 16}, {3, 2, 4});
+  generic_par_for_wg<1, class par_1d>({1000}, {20});
+  generic_par_for_wg<2, class par_2d_square>({100, 100}, {20, 20});
+  generic_par_for_wg<2, class par_2d_rect>({120, 120}, {10, 20});
+  generic_par_for_wg<2, class par_2d_rect>({120, 60}, {40, 10});
+  generic_par_for_wg<3, class par_3d_square>({100, 100, 100}, {20, 20, 20});
+  generic_par_for_wg<3, class par_3d_rect>({150, 200, 150}, {15, 20, 10});
+  generic_par_for_wg<3, class par_3d_rect>({150, 200, 100}, {15, 20, 4});
+
   return 0;
 }

--- a/tests/parallel_for/hierarchical_new.cpp
+++ b/tests/parallel_for/hierarchical_new.cpp
@@ -1,78 +1,108 @@
-/* RUN: %{execute}%s | %{filecheck} %s
-   CHECK: Group id = 0
-   CHECK: Local id = 0 (global id = 0)
-   CHECK: Local id = 1 (global id = 1)
-   CHECK: Global id = 0
-   CHECK: Global id = 1
-   CHECK: Group id = 1
-   CHECK: Local id = 0 (global id = 2)
-   CHECK: Local id = 1 (global id = 3)
-   CHECK: Global id = 2
-   CHECK: Global id = 3
-   CHECK: Group id = 2
-   CHECK: Local id = 0 (global id = 4)
-   CHECK: Local id = 1 (global id = 5)
-   CHECK: Global id = 4
-   CHECK: Global id = 5
-   CHECK: Group id = 3
-   CHECK: Local id = 0 (global id = 6)
-   CHECK: Local id = 1 (global id = 7)
-   CHECK: Global id = 6
-   CHECK: Global id = 7
-   CHECK: Group id = 4
-   CHECK: Local id = 0 (global id = 8)
-   CHECK: Local id = 1 (global id = 9)
-   CHECK: Global id = 8
-   CHECK: Global id = 9
-*/
+/* RUN: %{execute}%s
+ */
 
-/* The OpenMP based barrier use nested parallelism that makes order of
-   execution in parallel_for_workitem non deterministic so disable it on
-   this test
-*/
 #define TRISYCL_NO_BARRIER
 
-
-#include <vector>
 #include <CL/sycl.hpp>
+
+#include <boost/test/minimal.hpp>
 
 using namespace cl::sycl;
 
-int main() {
+template <int Dimensions, class kernel_name>
+void generic_par_for_wg(range<Dimensions> k_range,
+                        range<Dimensions> workgroup_size) {
   queue my_queue;
-  const int size = 10;
-  std::vector<int> data(size);
-  constexpr int groupsize = 2;
-/* Put &data[0] instead of data.data() because it is not obvious in the
-   excerpt below it is a vector */
-//////// Start slide
-buffer<int> input(&data[0], size);
-buffer<int> output(size);
-my_queue.submit([&](handler &cgh) {
-  auto in_access = input.get_access<access::mode::read>(cgh);
-  auto out_access = output.get_access<access::mode::write>(cgh);
 
-  cgh.parallel_for_work_group<class hierarchical>(nd_range<>(range<>(size),
-                                                             range<>(groupsize)),
-                                                  [=](group<> group) {
-    std::cout << "Group id = " << group.get_id(0) << std::endl;
+  // the product of all Dimensions e.g. 10*10*10 for {10,10,10}
+  auto linr_size = k_range.size(), linwg_size = workgroup_size.size();
 
-    group.parallel_for_work_item([=](h_item<1> tile) {
-      std::cout << "Local id = " << tile.get_local_id(0)
-                << " (global id = " << tile.get_global_id(0) << ")" << std::endl;
-      out_access[tile.get_global_id()] = in_access[tile.get_global_id()] * 2;
-    });
+  // these will simply have the group, local and global linear ids assigned to
+  // them
+  auto group_lin = buffer<int>(linr_size / linwg_size);
+  auto loc_lin = buffer<int>(linr_size);
+  auto gl_lin = buffer<int>(linr_size);
 
-    group.parallel_for_work_item([=](h_item<1> tile) {
-      std::cout << "Global id = " << tile.get_global_id(0) << std::endl;
-      out_access[tile.get_global_id()] = in_access[tile.get_global_id()] * 2;
-    });
+  // calculation to attain linr_size accross indices using values stored in
+  // gl_lin and indexed into by linear_id calls from the second kernel
+  auto loc_largest = buffer<int>(linr_size);
+  auto gl_calc = buffer<int>(linr_size);
+
+  my_queue.submit([&](handler &cgh) {
+    auto group_lin_acc = group_lin.get_access<access::mode::write>(cgh);
+    auto loc_lin_acc = loc_lin.get_access<access::mode::write>(cgh);
+    auto gl_lin_acc = gl_lin.get_access<access::mode::read_write>(cgh);
+    auto loc_largest_acc =
+        loc_largest.get_access<access::mode::read_write>(cgh);
+    auto gl_calc_acc = gl_calc.get_access<access::mode::read_write>(cgh);
+
+    cgh.parallel_for_work_group<kernel_name>(
+        nd_range<Dimensions>(k_range, workgroup_size),
+        [=](group<Dimensions> group) {
+          group_lin_acc[group.get_linear_id()] = group.get_linear_id();
+
+          group.parallel_for_work_item([=](h_item<Dimensions> tile) {
+            loc_lin_acc[tile.get_global_linear_id()] =
+                tile.get_local_linear_id();
+            gl_lin_acc[tile.get_global_linear_id()] =
+                tile.get_global_linear_id();
+
+            auto global =
+                group.get_linear_id() * linwg_size + tile.get_local_linear_id();
+            gl_calc_acc[global] = loc_largest_acc[global] = global;
+          });
+
+          group.parallel_for_work_item([=](h_item<Dimensions> tile) {
+            auto global =
+                group.get_linear_id() * linwg_size + tile.get_local_linear_id();
+
+            loc_largest_acc[global] +=
+                gl_calc_acc[((group.get_linear_id() + 1) * linwg_size) - 1 -
+                            tile.get_local_linear_id()];
+          });
+        });
   });
-});
-//////// End slide
+
+  auto loc_lin_out = loc_lin.get_access<access::mode::read>();
+  auto group_lin_out = group_lin.get_access<access::mode::read>();
+  auto gl_lin_out = gl_lin.get_access<access::mode::read>();
+
+  auto gl_calc_out = gl_calc.get_access<access::mode::read>();
+  auto loc_largest_out = loc_largest.get_access<access::mode::read>();
+
+  for (int i = 0; i < linr_size / linwg_size; ++i) {
+    BOOST_CHECK(group_lin_out[i] == i); // group id
+  }
+
+  int largest_local = 0;
+  for (int i = 0; i < linr_size; ++i) {
+    if (i % linwg_size == 0)
+      largest_local = gl_calc_out[i] + gl_calc_out[(i + linwg_size - 1)];
+    BOOST_CHECK(gl_lin_out[i] == i);                            // w1 global id
+    BOOST_CHECK(loc_lin_out[i] == loc_lin_out[i] % linwg_size); // local id
+    BOOST_CHECK(loc_largest_out[i] == largest_local);
+  }
+
   /* We must wait for for the queue to finish as none of buffer's destruction
      is blocking.
    */
   my_queue.wait();
+}
+
+int test_main(int argc, char *argv[]) {
+  generic_par_for_wg<1, class par_1d>({10}, {2});
+  generic_par_for_wg<2, class par_2d_square>({10, 10}, {2, 2});
+  generic_par_for_wg<2, class par_2d_square>({12, 12}, {4, 4});
+  generic_par_for_wg<2, class par_2d_rect>({12, 6}, {4, 2});
+  generic_par_for_wg<3, class par_3d_square>({10, 10, 10}, {2, 2, 2});
+  generic_par_for_wg<3, class par_3d_rect>({12, 8, 16}, {3, 2, 4});
+  generic_par_for_wg<1, class par_1d>({1000}, {20});
+  generic_par_for_wg<2, class par_2d_square>({100, 100}, {20, 20});
+  generic_par_for_wg<2, class par_2d_rect>({120, 120}, {10, 20});
+  generic_par_for_wg<2, class par_2d_rect>({120, 60}, {40, 10});
+  generic_par_for_wg<3, class par_3d_square>({100, 100, 100}, {20, 20, 20});
+  generic_par_for_wg<3, class par_3d_rect>({150, 200, 150}, {15, 20, 10});
+  generic_par_for_wg<3, class par_3d_rect>({150, 200, 100}, {15, 20, 4});
+
   return 0;
 }


### PR DESCRIPTION
I replaced the older OpenMP modulo/divison loop with a suggested newer 
implementation that uses OpenMP to collapse nested loops of different 
dimensions and uses constexpr to compile the appropriate one.

I think constexpr is cleaner than having several template 
specializations for each loop in this case.  

Related to triSYCL issue: https://github.com/triSYCL/triSYCL/issues/43