### PR TITLE
Additional Device Compiler Tests

### DIFF
--- a/tests/device_compiler/buffer_of_objects_member_functions.cpp
+++ b/tests/device_compiler/buffer_of_objects_member_functions.cpp
@@ -1,0 +1,74 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
+#include <boost/test/minimal.hpp>
+
+/*
+  The aim of this test is to check that C Struct objects can be used with
+  buffers (e.g. buffers of objects) and that function members can be accessed
+  and used to modify variables.
+
+  Current State:
+    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
+    compiler)
+    Untested with XOCL
+*/
+
+using namespace cl::sycl;
+
+constexpr size_t N = 32;
+
+struct Index_Member_Data {
+private:
+  std::size_t g;
+  std::size_t r;
+
+public:
+  Index_Member_Data() : g(0), r(0) {};
+
+  auto get_g() { return g; }
+  auto get_r() { return r; }
+  void set_g(std::size_t g_) { g = g_; }
+  void set_r(std::size_t r_) { r = r_; }
+};
+
+// check if standard layout and trivially copyable before execution, i.e. it's
+// POD (the type_trait is_pod is going to be deprecated in C++20)
+static_assert(std::is_standard_layout_v<Index_Member_Data> &&
+              std::is_trivially_copyable_v<Index_Member_Data>,
+              "Index_Member_Data is not POD");
+
+int test_main(int argc, char *argv[]) {
+  queue my_queue{default_selector{}};
+
+  buffer<Index_Member_Data, 1> a{N};
+
+  auto acc_w = a.get_access<access::mode::write>();
+  for (unsigned int i = 0; i < N; ++i) {
+    acc_w[i] = Index_Member_Data{};
+  }
+
+  my_queue.submit([&](handler &cgh) {
+    auto acc = a.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class buffer_of_objects_member_func>(
+        range<1>{N}, [d_a = drt::accessor<decltype(acc)>{acc}](item<1> index) {
+           d_a[index.get_id(0)].set_g(index.get_id(0));
+           d_a[index.get_id(0)].set_r(index.get_range()[0]);
+        });
+  });
+
+  my_queue.wait();
+
+  auto acc_r = a.get_access<access::mode::read>();
+
+  for (unsigned int i = 0; i < N; ++i) {
+    BOOST_CHECK(acc_r[i].get_r() == 32);
+    BOOST_CHECK(acc_r[i].get_g() == i);
+  }
+
+  return 0;
+}

--- a/tests/device_compiler/buffer_of_objects_member_functions.cpp
+++ b/tests/device_compiler/buffer_of_objects_member_functions.cpp
@@ -11,10 +11,8 @@
   buffers (e.g. buffers of objects) and that function members can be accessed
   and used to modify variables.
 
-  Current State:
-    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
-    compiler)
-    Untested with XOCL
+  Currently does not compile with XOCL when targeting hw_emu, address space
+  related bug.
 */
 
 using namespace cl::sycl;

--- a/tests/device_compiler/buffer_of_objects_members.cpp
+++ b/tests/device_compiler/buffer_of_objects_members.cpp
@@ -9,10 +9,6 @@
   The aim of this test is to check that C Struct objects can be used with
   buffers (e.g. buffers of objects) and that the data members can be accessed
   and modified trivially.
-
-  Current State:
-    Works with POCL
-    Untested with XOCL
 */
 
 using namespace cl::sycl;

--- a/tests/device_compiler/buffer_of_objects_members.cpp
+++ b/tests/device_compiler/buffer_of_objects_members.cpp
@@ -1,0 +1,65 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/test/minimal.hpp>
+
+/*
+  The aim of this test is to check that C Struct objects can be used with
+  buffers (e.g. buffers of objects) and that the data members can be accessed
+  and modified trivially.
+
+  Current State:
+    Works with POCL
+    Untested with XOCL
+*/
+
+using namespace cl::sycl;
+
+constexpr size_t N = 32;
+
+struct Index_Data {
+  Index_Data() : g(0), r(0) {};
+
+  std::size_t g;
+  std::size_t r;
+};
+
+// check if standard layout and trivially copyable before execution, i.e. it's
+// POD (the type_trait is_pod is going to be deprecated in C++20)
+static_assert(std::is_standard_layout_v<Index_Data> &&
+              std::is_trivially_copyable_v<Index_Data>,
+              "Index_Data is not POD");
+
+int test_main(int argc, char *argv[]) {
+  queue my_queue{default_selector{}};
+
+  buffer<Index_Data, 1> a{N};
+
+  auto acc_w = a.get_access<access::mode::write>();
+  for (unsigned int i = 0; i < N; ++i) {
+    acc_w[i] = Index_Data{};
+  }
+
+  my_queue.submit([&](handler &cgh) {
+    auto acc = a.get_access<access::mode::write>(cgh);
+
+    cgh.parallel_for<class buffer_of_objects_member_data>(
+        range<1>{N}, [d_a = drt::accessor<decltype(acc)>{acc}](item<1> index) {
+           d_a[index.get_id(0)].g = index.get_id(0);
+           d_a[index.get_id(0)].r = index.get_range()[0];
+        });
+  });
+
+  my_queue.wait();
+
+  auto acc_r = a.get_access<access::mode::read>();
+
+  for (unsigned int i = 0; i < N; ++i) {
+    BOOST_CHECK(acc_r[i].r == 32);
+    BOOST_CHECK(acc_r[i].g == i);
+  }
+
+  return 0;
+}

--- a/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
@@ -9,11 +9,6 @@
   A contrived test with the aim of testing that C++ objects can be created and
   destroyed inside a kernel implicitly and to detect any problems with
   address spaces that may occur in the process.
-
-  Current State:
-    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
-    compiler)
-    Untested with XOCL
 */
 
 using namespace cl::sycl;

--- a/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
@@ -1,0 +1,87 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/test/minimal.hpp>
+
+/*
+  A contrived test with the aim of testing that C++ objects can be created and
+  destroyed inside a kernel implicitly and to detect any problems with
+  address spaces that may occur in the process.
+
+  Current State:
+    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
+    compiler)
+    Untested with XOCL
+*/
+
+using namespace cl::sycl;
+
+constexpr size_t N = 32;
+
+class Index_Data {
+public:
+  Index_Data() : g(0), r(0) {};
+  ~Index_Data() {};
+
+  std::size_t g;
+  std::size_t r;
+
+};
+
+class Index_Member_Data {
+  std::size_t g;
+  std::size_t r;
+
+public:
+
+  Index_Member_Data() : g(0), r(0) {};
+  ~Index_Member_Data() {};
+
+  auto get_g() { return g; }
+  auto get_r() { return r; }
+  void set_g(std::size_t g_) { g = g_; }
+  void set_r(std::size_t r_) { r = r_; }
+};
+
+int test_main(int argc, char *argv[]) {
+  queue my_queue{default_selector{}};
+
+  buffer<unsigned int, 1> a{N};
+
+  auto acc_w = a.get_access<access::mode::write>();
+  for (unsigned int i = 0; i < N; ++i) {
+    acc_w[i] = 0;
+  }
+
+  Index_Member_Data idm_outer;
+  idm_outer.set_g(20);
+  idm_outer.set_r(20);
+
+  my_queue.submit([&](handler &cgh) {
+    auto acc = a.get_access<access::mode::write>(cgh);
+
+    Index_Member_Data idm_inner;
+    idm_inner.set_g(10);
+    idm_inner.set_r(10);
+
+    cgh.parallel_for<class ctor_dtor>(
+        range<1>{N}, [&, d_a = drt::accessor<decltype(acc)>{acc}](item<1> index) {
+           Index_Data id;
+           id.g = index.get_id(0) + idm_inner.get_g() + idm_outer.get_g();
+           id.r = index.get_range()[0]  + idm_inner.get_r() + idm_outer.get_r();
+           d_a[index.get_id(0)] = id.g + id.r;
+        });
+  });
+
+  my_queue.wait();
+
+  auto acc_r = a.get_access<access::mode::read>();
+
+  for (unsigned int i = 0; i < N; ++i) {
+    BOOST_CHECK(acc_r[i] == i + 32 + 60);
+  }
+
+  return 0;
+}

--- a/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/parallel_for_class_ctor_and_dtor.cpp
@@ -27,7 +27,6 @@ public:
 
   std::size_t g;
   std::size_t r;
-
 };
 
 class Index_Member_Data {
@@ -35,12 +34,11 @@ class Index_Member_Data {
   std::size_t r;
 
 public:
-
   Index_Member_Data() : g(0), r(0) {};
   ~Index_Member_Data() {};
 
-  auto get_g() { return g; }
-  auto get_r() { return r; }
+  auto get_g() const { return g; }
+  auto get_r() const { return r; }
   void set_g(std::size_t g_) { g = g_; }
   void set_r(std::size_t r_) { r = r_; }
 };
@@ -67,7 +65,7 @@ int test_main(int argc, char *argv[]) {
     idm_inner.set_r(10);
 
     cgh.parallel_for<class ctor_dtor>(
-        range<1>{N}, [&, d_a = drt::accessor<decltype(acc)>{acc}](item<1> index) {
+        range<1>{N}, [=, d_a = drt::accessor<decltype(acc)>{acc}](item<1> index) {
            Index_Data id;
            id.g = index.get_id(0) + idm_inner.get_g() + idm_outer.get_g();
            id.r = index.get_range()[0]  + idm_inner.get_r() + idm_outer.get_r();

--- a/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
@@ -9,11 +9,6 @@
   A contrived test with the aim of testing that C++ objects can be created and
   destroyed inside a kernel implicitly and to detect any problems with address
   spaces that may occur in the process.
-
-  Current State:
-    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
-    compiler)
-    Untested with XOCL
 */
 
 using namespace cl::sycl;

--- a/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
@@ -1,0 +1,81 @@
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/test/minimal.hpp>
+
+/*
+  A contrived test with the aim of testing that C++ objects can be created and
+  destroyed inside a kernel implicitly and to detect any problems with address
+  spaces that may occur in the process.
+
+  Current State:
+    Works with POCL (tested with top of tree (10/13/2018) triSYCL device
+    compiler)
+    Untested with XOCL
+*/
+
+using namespace cl::sycl;
+
+constexpr size_t N = 32;
+
+class Index_Data {
+public:
+  Index_Data() : g(0) {}
+  ~Index_Data() {}
+
+  std::size_t g;
+};
+
+class Index_Member_Data {
+  std::size_t g;
+
+public:
+  Index_Member_Data() : g(0) {}
+  ~Index_Member_Data() {}
+
+  auto get_g() { return g; }
+  void set_g(std::size_t g_) { g = g_; }
+};
+
+int test_main(int argc, char *argv[]) {
+
+    queue my_queue{default_selector{}};
+
+    buffer<unsigned int, 1> a{N};
+
+    auto acc_w = a.get_access<access::mode::write>();
+    for (unsigned int i = 0; i < N; ++i) {
+      acc_w[i] = 0;
+    }
+
+    Index_Member_Data idm_outer;
+    idm_outer.set_g(20);
+
+    my_queue.submit([&](handler &cgh) {
+      auto acc = a.get_access<access::mode::write>(cgh);
+
+      Index_Member_Data idm_inner;
+      idm_inner.set_g(10);
+
+      cgh.single_task<class ctor_dtor>(
+        [&, d_a = drt::accessor<decltype(acc)>{acc}] {
+            for (unsigned int i = 0 ; i < N; ++i) {
+              Index_Data id;
+              id.g = i + idm_inner.get_g() + idm_outer.get_g();
+              d_a[i] = id.g;
+            }
+        });
+    });
+
+    my_queue.wait();
+
+    auto acc_r = a.get_access<access::mode::read>();
+
+    for (unsigned int i = 0; i < N; ++i) {
+      BOOST_CHECK(acc_r[i] == i + 30);
+    }
+
+    return 0;
+}

--- a/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
+++ b/tests/device_compiler/single_task_class_ctor_and_dtor.cpp
@@ -35,7 +35,7 @@ public:
   Index_Member_Data() : g(0) {}
   ~Index_Member_Data() {}
 
-  auto get_g() { return g; }
+  auto get_g() const { return g; }
   void set_g(std::size_t g_) { g = g_; }
 };
 
@@ -60,7 +60,7 @@ int test_main(int argc, char *argv[]) {
       idm_inner.set_g(10);
 
       cgh.single_task<class ctor_dtor>(
-        [&, d_a = drt::accessor<decltype(acc)>{acc}] {
+        [=, d_a = drt::accessor<decltype(acc)>{acc}] {
             for (unsigned int i = 0 ; i < N; ++i) {
               Index_Data id;
               id.g = i + idm_inner.get_g() + idm_outer.get_g();


### PR DESCRIPTION
Several new device compiler tests that work with POCL when they're
compiled using a newer version of the triSYCL device compiler (after the
commit: [OpenCL] Add generic AS to 'this' pointer).

However, the buffer_of_objects_members.cpp test works with the
sycl/release_70/master branch of the triSYCL device compiler.

The buffer of objects tests are related to:
https://github.com/triSYCL/triSYCL/issues/212

The ctor_and_dtor tests are related to:
https://github.com/triSYCL/triSYCL/issues/213