### PR TITLE
[WIP] Refactor the accessor implementation to be more device friendly

### DIFF
--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -12,9 +12,9 @@
 #include <cstddef>
 
 #include "CL/sycl/access.hpp"
+#include "CL/sycl/accessor/detail/accessor_traits.hpp"
 #include "CL/sycl/accessor/detail/local_accessor.hpp"
 #include "CL/sycl/buffer/detail/accessor.hpp"
-#include "CL/sycl/detail/container_element_aspect.hpp"
 #include "CL/sycl/detail/shared_ptr_implementation.hpp"
 #include "CL/sycl/id.hpp"
 #include "CL/sycl/item.hpp"
@@ -53,7 +53,7 @@ class accessor :
                                                               Dimensions,
                                                               AccessMode,
                                                               Target>>,
-    public detail::container_element_aspect<DataType> {
+    public detail::accessor_traits<DataType, Dimensions, AccessMode, Target> {
 
  public:
 
@@ -444,7 +444,9 @@ public:
 template <typename DataType,
           access::mode AccessMode>
 class accessor<DataType, 1, AccessMode, access::target::blocking_pipe> :
-    public detail::pipe_accessor<DataType, AccessMode, access::target::blocking_pipe> {
+    public detail::pipe_accessor<DataType,
+                                 AccessMode,
+                                 access::target::blocking_pipe> {
 public:
 
   using accessor_detail =

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -10,6 +10,7 @@
 */
 
 #include <cstddef>
+#include <memory>
 
 #include "CL/sycl/access.hpp"
 #include "CL/sycl/accessor/detail/accessor_traits.hpp"
@@ -22,8 +23,7 @@
 #include "CL/sycl/pipe_reservation.hpp"
 #include "CL/sycl/pipe/detail/pipe_accessor.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <typename T, int Dimensions, typename Allocator>
 class buffer;
@@ -45,38 +45,27 @@ template <typename DataType,
           access::mode AccessMode,
           access::target Target = access::target::global_buffer>
 class accessor :
-    public detail::shared_ptr_implementation<accessor<DataType,
-                                                      Dimensions,
-                                                      AccessMode,
-                                                      Target>,
-                                             detail::accessor<DataType,
-                                                              Dimensions,
-                                                              AccessMode,
-                                                              Target>>,
-    public detail::accessor_traits<DataType, Dimensions, AccessMode, Target> {
-
- public:
-
-  /// \todo in the specification: store the dimension for user request
-  static constexpr auto dimensionality = Dimensions;
+    public detail::buffer_accessor_view<DataType
+                                        , Dimensions
+                                        , AccessMode
+                                        , Target> {
 
  private:
 
-  using accessor_detail = typename detail::accessor<DataType,
-                                                    Dimensions,
-                                                    AccessMode,
-                                                    Target>;
+  using accessor_view = typename detail::buffer_accessor_view<DataType
+                                                              , Dimensions
+                                                              , AccessMode
+                                                              , Target>;
 
-  // The type encapsulating the implementation
-  using implementation_t = typename accessor::shared_ptr_implementation;
-
-  // Allows the comparison operation to access the implementation
-  friend implementation_t;
+  using shepherd = typename detail::accessor<DataType
+                                             , Dimensions
+                                             , AccessMode
+                                             , Target>;
 
  public:
 
   // Make the implementation member directly accessible in this class
-  using implementation_t::implementation;
+  using accessor_view::buffer_accessor_view;
 
   /** Construct a buffer accessor from a buffer using a command group
       handler object from the command group scope
@@ -95,16 +84,20 @@ class accessor :
   */
   template <typename Allocator>
   accessor(buffer<DataType, Dimensions, Allocator> &target_buffer,
-           handler &command_group_handler) : implementation_t {
-    new detail::accessor<DataType, Dimensions, AccessMode, Target> {
-      target_buffer.implementation->implementation, command_group_handler }
-  } {
+           handler &command_group_handler)
+    : accessor_view {
+        target_buffer.implementation->implementation->get_access()
+      }
+  {
+    auto s =
+      std::make_shared<shepherd>(target_buffer.implementation->implementation,
+                                 command_group_handler);
     static_assert(Target == access::target::global_buffer
                   || Target == access::target::constant_buffer,
                   "access target should be global_buffer or constant_buffer "
                   "when a handler is used");
-    // Now the implementation is created, register it
-    implementation->register_accessor();
+    // Now the accessor shepherd is created, register it
+    s->register_accessor();
   }
 
 
@@ -116,14 +109,17 @@ class accessor :
   */
   template <typename Allocator>
   accessor(buffer<DataType, Dimensions, Allocator> &target_buffer)
-    : implementation_t {
-    new detail::accessor<DataType, Dimensions, AccessMode, Target> {
-      target_buffer.implementation->implementation }
-  } {
+    : accessor_view {
+        target_buffer.implementation->implementation->get_access()
+      }
+  {
     static_assert(Target == access::target::host_buffer,
                   "without a handler, access target should be host_buffer");
+    auto s =
+      std::make_shared<shepherd>(target_buffer.implementation->implementation);
+    // \todo Do we need to extend the life of shepherd further?
+    // Probably to fix with https://github.com/triSYCL/triSYCL/issues/192
   }
-
 
   /** Construct a buffer accessor from a buffer given a specific range for
       access permissions and an offset that provides the starting point
@@ -161,6 +157,7 @@ class accessor :
   */
   accessor(const range<Dimensions> &allocation_size,
            handler &command_group_handler)
+#if 0
     : implementation_t { new detail::accessor<DataType,
                                               Dimensions,
                                               AccessMode,
@@ -173,231 +170,13 @@ class accessor :
                   "This accessor constructor requires "
                   "access target be local");
   }
+#endif
+{}
 
-
-  /** Return a range object representing the size of the buffer in
-      terms of number of elements in each dimension as passed to the
-      constructor
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_range() const {
-    /* Interpret the shape which is a pointer to the first element as an
-       array of Dimensions elements so that the range<Dimensions>
-       constructor is happy with this collection
-
-       \todo Add also a constructor in range<> to accept a const
-       std::size_t *?
-    */
-    return implementation->get_range();
-  }
-
-
-  /** Returns the total number of elements behind the accessor
-
-      Equal to get_range()[0] * ... * get_range()[Dimensions-1].
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_count() const {
-    return implementation->get_count();
-  }
-
-
-  /** Returns the size of the underlying buffer storage in bytes
-
-      \todo It is incompatible with buffer get_size() in the spec
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_size() const {
-    return implementation->get_size();
-  }
-
-
-  /** Use the accessor with integers à la [][][]
-
-      Use array_view_type::reference instead of auto& because it does not
-      work in some dimensions.
-   */
-  typename accessor_detail::reference operator[](std::size_t index) {
-//#ifdef TRISYCL_DEVICE
-//#else
-    return (*implementation)[index];
-//#endif
-  }
-
-
-  /** Use the accessor with integers à la [][][]
-
-      Use array_view_type::reference instead of auto& because it does not
-      work in some dimensions.
-   */
-  typename accessor_detail::reference operator[](std::size_t index) const {
-    return (*implementation)[index];
-  }
-
-
-  /// To use the accessor with [id<>]
-  auto &operator[](id<dimensionality> index) {
-    return (*implementation)[index];
-  }
-
-
-  /// To use the accessor with [id<>]
-  auto &operator[](id<dimensionality> index) const {
-    return (*implementation)[index];
-  }
-
-
-  /// To use an accessor with [item<>]
-  auto &operator[](item<dimensionality> index) {
-    return (*this)[index.get_id()];
-  }
-
-
-  /// To use an accessor with [item<>]
-  auto &operator[](item<dimensionality> index) const {
-    return (*this)[index.get_id()];
-  }
-
-
-  /** To use an accessor with an [nd_item<>]
-
-      \todo Add in the specification because used by HPC-GPU slide 22
-  */
-  auto &operator[](nd_item<dimensionality> index) {
-    return (*this)[index.get_global_id()];
-  }
-
-  /** To use an accessor with an [nd_item<>]
-
-      \todo Add in the specification because used by HPC-GPU slide 22
-  */
-  auto &operator[](nd_item<dimensionality> index) const {
-    return (*this)[index.get_global_id()];
-  }
-
-
-    /** Get the first element of the accessor
-
-      Useful with an accessor on a scalar for example.
-
-      \todo Add in the specification
-  */
-  typename accessor_detail::reference operator*() {
-    return **implementation;
-  }
-
-
-  /** Get the first element of the accessor
-
-      Useful with an accessor on a scalar for example.
-
-      \todo Add in the specification?
-
-      \todo Add the concept of 0-dim buffer and accessor for scalar
-      and use an implicit conversion to value_type reference to access
-      the value with the accessor?
-  */
-  typename accessor_detail::reference operator*() const {
-    return **implementation;
-  }
-
-
-  /** Get the pointer to the start of the data
-
-      \todo Should it be named data() instead? */
-  auto
-  get_pointer() const {
-    return implementation->get_pointer();
-  }
-
-
-  /** Forward all the iterator functions to the implementation
-
-      \todo Add these functions to the specification
-
-      \todo The fact that the lambda capture make a const copy of the
-      accessor is not yet elegantly managed... The issue is that
-      begin()/end() dispatch is made according to the accessor
-      constness and not from the array member constness...
-
-      \todo try to solve it by using some enable_if on array
-      constness?
-
-      \todo The issue is that the end may not be known if it is
-      implemented by a raw OpenCL cl_mem... So only provide on the
-      device the iterators related to the start? Actually the accessor
-      needs to know a part of the shape to have the multidimentional
-      addressing. So this only require a size_t more...
-
-      \todo Factor out these in a template helper
-  */
-
-
-  // iterator begin() { return array.begin(); }
-  typename accessor_detail::iterator begin() const {
-    return implementation->begin();
-  }
-
-
-  // iterator end() { return array.end(); }
-  typename accessor_detail::iterator end() const {
-    return implementation->end();
-  }
-
-
-  // const_iterator begin() const { return implementation->begin(); }
-
-
-  // const_iterator end() const { return implementation->end(); }
-
-
-  typename accessor_detail::const_iterator cbegin() const {
-    return implementation->cbegin();
-  }
-
-
-  typename accessor_detail::const_iterator cend() const {
-    return implementation->cend();
-  }
-
-
-  typename accessor_detail::reverse_iterator rbegin() const {
-    return implementation->rbegin();
-  };
-
-
-  typename accessor_detail::reverse_iterator rend() const {
-    return implementation->rend();
-  }
-
-
-  // const_reverse_iterator rbegin() const { return array.rbegin(); }
-
-
-  // const_reverse_iterator rend() const { return array.rend(); }
-
-
-  typename accessor_detail::const_reverse_iterator crbegin() const {
-    return implementation->rbegin();
-  }
-
-
-  typename accessor_detail::const_reverse_iterator crend() const {
-    return implementation->rend();
-  }
 
 };
 
-
+#if 0
 /** The pipe accessor abstracts the way pipe data are accessed inside
     a kernel
 
@@ -482,7 +261,7 @@ public:
   }
 
 };
-
+#endif
 
 /** Top-level function to break circular dependencies on the the types
     to get the pipe implementation */
@@ -493,7 +272,6 @@ static inline auto &get_pipe_detail(Accessor &a) {
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/accessor/detail/accessor_traits.hpp
+++ b/include/CL/sycl/accessor/detail/accessor_traits.hpp
@@ -9,6 +9,7 @@
     License. See LICENSE.TXT for details.
 */
 
+#include "CL/sycl/detail/container_element_aspect.hpp"
 
 namespace cl {
 namespace sycl {
@@ -22,7 +23,7 @@ template <typename T,
           int Dimensions,
           access::mode Mode,
           access::target Target>
-class accessor_traits {
+class accessor_traits : public detail::container_element_aspect<T> {
 
 public:
 
@@ -37,13 +38,6 @@ public:
 
   //* \todo in the specification: store the target for user request
   static constexpr auto target = Target;
-
-  /** \todo in the specification: store the types for user request as STL
-      or C++AMP */
-  using value_type = T;
-  using element = T;
-  using reference = value_type &;
-  using const_reference = const value_type &;
 
 };
 

--- a/include/CL/sycl/accessor/detail/accessor_traits.hpp
+++ b/include/CL/sycl/accessor/detail/accessor_traits.hpp
@@ -1,0 +1,64 @@
+#ifndef TRISYCL_SYCL_ACCESSOR_DETAIL_ACCESSOR_TRAITS_HPP
+#define TRISYCL_SYCL_ACCESSOR_DETAIL_ACCESSOR_TRAITS_HPP
+
+/** \file Some information common to SYCL accessor<>
+
+    Ronan at Keryell point FR
+
+    This file is distributed under the University of Illinois Open Source
+    License. See LICENSE.TXT for details.
+*/
+
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+/** \addtogroup data Data access and storage in SYCL
+    @{
+*/
+
+template <typename T,
+          int Dimensions,
+          access::mode Mode,
+          access::target Target>
+class accessor_traits {
+
+public:
+
+  /** \todo in the specification: store the dimension for user request
+
+      \todo Use another name, such as from C++2a committee discussions.
+   */
+  static constexpr auto dimensionality = Dimensions;
+
+  //* \todo in the specification: store the mode for user request
+  static constexpr auto mode = Mode;
+
+  //* \todo in the specification: store the target for user request
+  static constexpr auto target = Target;
+
+  /** \todo in the specification: store the types for user request as STL
+      or C++AMP */
+  using value_type = T;
+  using element = T;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+
+};
+
+/// @} End the data Doxygen group
+
+}
+}
+}
+
+/*
+    # Some Emacs stuff:
+    ### Local Variables:
+    ### ispell-local-dictionary: "american"
+    ### eval: (flyspell-prog-mode)
+    ### End:
+*/
+
+#endif // TRISYCL_SYCL_ACCESSOR_DETAIL_ACCESSOR_TRAITS_HPP

--- a/include/CL/sycl/buffer/detail/accessor.hpp
+++ b/include/CL/sycl/buffer/detail/accessor.hpp
@@ -15,15 +15,12 @@
 #ifdef TRISYCL_OPENCL
 #include <boost/compute.hpp>
 #endif
-#include <boost/multi_array.hpp>
 
 #include "CL/sycl/access.hpp"
 #include "CL/sycl/accessor/detail/accessor_base.hpp"
+#include "CL/sycl/buffer/detail/buffer_accessor_view.hpp"
 #include "CL/sycl/command_group/detail/task.hpp"
 #include "CL/sycl/detail/debug.hpp"
-#include "CL/sycl/id.hpp"
-#include "CL/sycl/item.hpp"
-#include "CL/sycl/nd_item.hpp"
 
 namespace cl {
 namespace sycl {
@@ -58,14 +55,12 @@ template <typename T,
           access::target Target /* = access::global_buffer */>
 class accessor :
     public detail::accessor_base,
+    public detail::buffer_accessor_view<T, Dimensions, Mode, Target>,
     public std::enable_shared_from_this<accessor<T,
                                                  Dimensions,
                                                  Mode,
                                                  Target>>,
-    public detail::debug<accessor<T,
-                                  Dimensions,
-                                  Mode,
-                                  Target>> {
+    public detail::debug<accessor<T, Dimensions, Mode, Target>> {
   /** Keep a reference to the accessed buffer
 
       Beware that it owns the buffer, which means that the accessor
@@ -74,47 +69,7 @@ class accessor :
   */
   std::shared_ptr<detail::buffer<T, Dimensions>> buf;
 
-  /// The implementation is a multi_array_ref wrapper
-  using array_view_type = boost::multi_array_ref<T, Dimensions>;
-
-  // The same type but writable
-  using writable_array_view_type =
-    typename std::remove_const<array_view_type>::type;
-
-  /** The way the buffer is really accessed
-
-      Use a mutable member because the accessor needs to be captured
-      by value in the lambda which is then read-only. This is to avoid
-      the user to use mutable lambda or have a lot of const_cast as
-      previously done in this implementation
-   */
-  mutable array_view_type array;
-
 public:
-
-  /** \todo in the specification: store the dimension for user request
-
-      \todo Use another name, such as from C++17 committee discussions.
-   */
-  static constexpr auto dimensionality = Dimensions;
-
-  /** \todo in the specification: store the types for user request as STL
-      or C++AMP */
-  using value_type = T;
-  using element = T;
-  using reference = typename array_view_type::reference;
-  using const_reference = typename array_view_type::const_reference;
-
-  /** Inherit the iterator types from the implementation
-
-      \todo Add iterators to accessors in the specification
-  */
-  using iterator = typename array_view_type::iterator;
-  using const_iterator = typename array_view_type::const_iterator;
-  using reverse_iterator = typename array_view_type::reverse_iterator;
-  using const_reverse_iterator =
-    typename array_view_type::const_reverse_iterator;
-
 
   /** Construct a host accessor from an existing buffer
 
@@ -122,9 +77,13 @@ public:
       template parm
   */
   accessor(std::shared_ptr<detail::buffer<T, Dimensions>> target_buffer) :
-    buf { target_buffer }, array { target_buffer->access } {
+    detail::buffer_accessor_view<T, Dimensions, Mode, Target> {
+      target_buffer->access },
+    buf { target_buffer }
+  {
     target_buffer->template track_access_mode<Mode>();
-    TRISYCL_DUMP_T("Create a host accessor write = " << is_write_access());
+    TRISYCL_DUMP_T("Create a host accessor write = "
+                   << accessor::is_write_access());
     static_assert(Target == access::target::host_buffer,
                   "without a handler, access target should be host_buffer");
     /* The host needs to wait for all the producers of the buffer to
@@ -138,7 +97,8 @@ public:
        host accessors are blocking
      */
     cl::sycl::context ctx;
-    buf->update_buffer_state(ctx, Mode, get_size(), array.data());
+    buf->update_buffer_state(ctx, accessor::mode, accessor::get_size(),
+                             accessor::get_pointer());
 #endif
   }
 
@@ -150,15 +110,20 @@ public:
   */
   accessor(std::shared_ptr<detail::buffer<T, Dimensions>> target_buffer,
            handler &command_group_handler) :
-    buf { target_buffer }, array { target_buffer->access } {
+    detail::buffer_accessor_view<T, Dimensions, Mode, Target> {
+      target_buffer->access },
+    buf { target_buffer }
+  {
     target_buffer->template track_access_mode<Mode>();
-    TRISYCL_DUMP_T("Create a kernel accessor write = " << is_write_access());
+    TRISYCL_DUMP_T("Create a kernel accessor write = "
+                   << accessor::is_write_access());
     static_assert(Target == access::target::global_buffer
                   || Target == access::target::constant_buffer,
                   "access target should be global_buffer or constant_buffer "
                   "when a handler is used");
     // Register the buffer to the task dependencies
-    task = buffer_add_to_task(buf, &command_group_handler, is_write_access());
+    task = buffer_add_to_task(buf, &command_group_handler,
+                              accessor::is_write_access());
   }
 
 
@@ -196,256 +161,10 @@ public:
   }
 
 
-  /** Return a range object representing the size of the buffer in
-      terms of number of elements in each dimension as passed to the
-      constructor
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_range() const {
-    /* Interpret the shape which is a pointer to the first element as an
-       array of Dimensions elements so that the range<Dimensions>
-       constructor is happy with this collection
-
-       \todo Add also a constructor in range<> to accept a const
-       std::size_t *?
-    */
-    return range<Dimensions> {
-      *(const std::size_t (*)[Dimensions])(array.shape())
-        };
-  }
-
-
-  /** Returns the total number of elements behind the accessor
-
-      Equal to get_range()[0] * ... * get_range()[Dimensions-1].
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_count() const {
-    return array.num_elements();
-  }
-
-
-  /** Returns the size of the underlying buffer storage in bytes
-
-      \todo Move on
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
-      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
-  */
-  auto get_size() const {
-    return get_count()*sizeof(value_type);
-  }
-
-
-  /** Use the accessor with integers à la [][][]
-
-      Use array_view_type::reference instead of auto& because it does not
-      work in some dimensions.
-   */
-  reference operator[](std::size_t index) {
-    return array[index];
-  }
-
-
-  /** Use the accessor with integers à la [][][]
-
-      Use array_view_type::reference instead of auto& because it does not
-      work in some dimensions.
-   */
-  reference operator[](std::size_t index) const {
-    return array[index];
-  }
-
-
-  /// To use the accessor with [id<>]
-  auto &operator[](id<dimensionality> index) {
-    return array(index);
-  }
-
-
-  /// To use the accessor with [id<>]
-  auto &operator[](id<dimensionality> index) const {
-    return array(index);
-  }
-
-
-  /// To use an accessor with [item<>]
-  auto &operator[](item<dimensionality> index) {
-    return (*this)[index.get()];
-  }
-
-
-  /// To use an accessor with [item<>]
-  auto &operator[](item<dimensionality> index) const {
-    return (*this)[index.get()];
-  }
-
-
-  /** To use an accessor with an [nd_item<>]
-
-      \todo Add in the specification because used by HPC-GPU slide 22
-  */
-  auto &operator[](nd_item<dimensionality> index) {
-    return (*this)[index.get_global()];
-  }
-
-  /** To use an accessor with an [nd_item<>]
-
-      \todo Add in the specification because used by HPC-GPU slide 22
-  */
-  auto &operator[](nd_item<dimensionality> index) const {
-    return (*this)[index.get_global()];
-  }
-
-
-  /** Get the first element of the accessor
-
-      Useful with an accessor on a scalar for example.
-
-      \todo Add in the specification
-  */
-  reference operator*() {
-    return *array.data();
-  }
-
-
-  /** Get the first element of the accessor
-
-      Useful with an accessor on a scalar for example.
-
-      \todo Add in the specification?
-
-      \todo Add the concept of 0-dim buffer and accessor for scalar
-      and use an implicit conversion to value_type reference to access
-      the value with the accessor?
-  */
-  reference operator*() const {
-    return *array.data();
-  }
-
-
   /// Get the buffer used to create the accessor
   detail::buffer<T, Dimensions> &get_buffer() {
     return *buf;
   }
-
-
-  /** Test if the accessor has a read access right
-
-      \todo Strangely, it is not really constexpr because it is not a
-      static method...
-
-      \todo to move in the access::mode enum class and add to the
-      specification ?
-  */
-  constexpr bool is_read_access() const {
-    return Mode == access::mode::read
-      || Mode == access::mode::read_write
-      || Mode == access::mode::discard_read_write;
-  }
-
-
-  /** Test if the accessor has a write access right
-
-      \todo Strangely, it is not really constexpr because it is not a
-      static method...
-
-      \todo to move in the access::mode enum class and add to the
-      specification ?
-  */
-  constexpr bool is_write_access() const {
-    return Mode == access::mode::write
-      || Mode == access::mode::read_write
-      || Mode == access::mode::discard_write
-      || Mode == access::mode::discard_read_write;
-  }
-
-
-  /** Return the pointer to the data
-
-      \todo Implement the various pointer address spaces
-  */
-  auto
-  get_pointer() const {
-    return array.data();
-  }
-
-
-  /** Forward all the iterator functions to the implementation
-
-      \todo Add these functions to the specification
-
-      \todo The fact that the lambda capture make a const copy of the
-      accessor is not yet elegantly managed... The issue is that
-      begin()/end() dispatch is made according to the accessor
-      constness and not from the array member constness...
-
-      \todo try to solve it by using some enable_if on array
-      constness?
-
-      \todo The issue is that the end may not be known if it is
-      implemented by a raw OpenCL cl_mem... So only provide on the
-      device the iterators related to the start? Actually the accessor
-      needs to know a part of the shape to have the multidimentional
-      addressing. So this only require a size_t more...
-
-      \todo Factor out these in a template helper
-
-      \todo Do we need this in detail::accessor too or only in accessor?
-  */
-
-
-  // iterator begin() { return array.begin(); }
-  iterator begin() const {
-    return const_cast<writable_array_view_type &>(array).begin();
-  }
-
-
-  // iterator end() { return array.end(); }
-  iterator end() const {
-    return const_cast<writable_array_view_type &>(array).end();
-  }
-
-
-  // const_iterator begin() const { return array.begin(); }
-
-
-  // const_iterator end() const { return array.end(); }
-
-
-  const_iterator cbegin() const { return array.begin(); }
-
-
-  const_iterator cend() const { return array.end(); }
-
-
-  // reverse_iterator rbegin() { return array.rbegin(); }
-  reverse_iterator rbegin() const {
-    return const_cast<writable_array_view_type &>(array).rbegin();
-  }
-
-
-  // reverse_iterator rend() { return array.rend(); }
-  reverse_iterator rend() const {
-    return const_cast<writable_array_view_type &>(array).rend();
-  }
-
-
-  // const_reverse_iterator rbegin() const { return array.rbegin(); }
-
-
-  // const_reverse_iterator rend() const { return array.rend(); }
-
-
-  const_reverse_iterator crbegin() const { return array.rbegin(); }
-
-
-  const_reverse_iterator crend() const { return array.rend(); }
 
 private:
 
@@ -469,7 +188,8 @@ private:
        the buffer doesn't already exists or if the data is not up to date
     */
     auto ctx = task->get_queue()->get_context();
-    buf->update_buffer_state(ctx, Mode, get_size(), array.data());
+    buf->update_buffer_state(ctx, accessor::mode, accessor::get_size(),
+                             accessor::get_pointer());
   }
 
 

--- a/include/CL/sycl/buffer/detail/accessor.hpp
+++ b/include/CL/sycl/buffer/detail/accessor.hpp
@@ -22,8 +22,7 @@
 #include "CL/sycl/command_group/detail/task.hpp"
 #include "CL/sycl/detail/debug.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -77,6 +76,7 @@ public:
       template parm
   */
   accessor(std::shared_ptr<detail::buffer<T, Dimensions>> target_buffer) :
+//remove?
     detail::buffer_accessor_view<T, Dimensions, Mode, Target> {
       target_buffer->access },
     buf { target_buffer }
@@ -110,6 +110,7 @@ public:
   */
   accessor(std::shared_ptr<detail::buffer<T, Dimensions>> target_buffer,
            handler &command_group_handler) :
+//remove?
     detail::buffer_accessor_view<T, Dimensions, Mode, Target> {
       target_buffer->access },
     buf { target_buffer }
@@ -153,7 +154,10 @@ public:
       task->add_postlude([=] {
           /* Even if this function does nothing, it is required to
              have the capture of acc to keep the accessor alive across
-             the kernel execution up to the execution postlude */
+             the kernel execution up to the execution postlude.
+
+             Note that this is what will destroy the accessor shepherd
+             after the kernel execution */
           acc->copy_back_cl_buffer();
         });
 #endif
@@ -208,7 +212,6 @@ private:
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -23,10 +23,7 @@
 #include "CL/sycl/buffer/detail/buffer_waiter.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
-
+namespace cl::sycl::detail {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -54,6 +51,7 @@ public:
 
 private:
 
+//Remove
   // \todo Replace U and D somehow by T and Dimensions
   // To allow allocation access
   template <typename U,
@@ -214,6 +212,12 @@ public:
    */
   void mark_as_written() {
     modified = true;
+  }
+
+
+  /// Return a low-level accessor on the buffer
+  auto& get_access() {
+    return access ;
   }
 
 
@@ -434,8 +438,6 @@ buffer_add_to_task(BufferDetail buf,
 
 /// @} End the data Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
@@ -18,6 +18,7 @@
 #include <boost/multi_array.hpp>
 
 #include "CL/sycl/access.hpp"
+#include "CL/sycl/accessor/detail/accessor_traits.hpp"
 #include "CL/sycl/id.hpp"
 #include "CL/sycl/item.hpp"
 #include "CL/sycl/nd_item.hpp"
@@ -30,9 +31,15 @@ template <typename T,
           int Dimensions,
           access::mode Mode,
           access::target Target>
-class buffer_accessor_view {
+class buffer_accessor_view :
+    public detail::accessor_traits<T, Dimensions, Mode, Target> {
 
 public:
+
+  // To make these accessor traits directly usable inside this class
+  using typename
+    detail::accessor_traits<T, Dimensions, Mode, Target>::value_type;
+  using detail::accessor_traits<T, Dimensions, Mode, Target>::dimensionality;
 
   /// The implementation is a multi_array_ref wrapper
   using array_view_type = boost::multi_array_ref<T, Dimensions>;
@@ -41,22 +48,8 @@ public:
   using writable_array_view_type =
     typename std::remove_const<array_view_type>::type;
 
-  /** \todo in the specification: store the dimension for user request
-
-      \todo Use another name, such as from C++2a committee discussions.
-   */
-  static constexpr auto dimensionality = Dimensions;
-
-  //* \todo in the specification: store the mode for user request
-  static constexpr auto mode = Mode;
-
-  //* \todo in the specification: store the target for user request
-  static constexpr auto target = Target;
-
-  /** \todo in the specification: store the types for user request as STL
-      or C++AMP */
-  using value_type = T;
-  using element = T;
+  // Override the accessor traits by the implementation details to
+  // have multidimensional arrays working
   using reference = typename array_view_type::reference;
   using const_reference = typename array_view_type::const_reference;
 

--- a/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
@@ -37,9 +37,11 @@ class buffer_accessor_view :
 public:
 
   // To make these accessor traits directly usable inside this class
+  using detail::accessor_traits<T, Dimensions, Mode, Target>::dimensionality;
+  using typename
+    detail::accessor_traits<T, Dimensions, Mode, Target>::pointer;
   using typename
     detail::accessor_traits<T, Dimensions, Mode, Target>::value_type;
-  using detail::accessor_traits<T, Dimensions, Mode, Target>::dimensionality;
 
   /// The implementation is a multi_array_ref wrapper
   using array_view_type = boost::multi_array_ref<T, Dimensions>;
@@ -74,8 +76,15 @@ public:
   */
   mutable array_view_type array;
 
+  //* Make a buffer_accessor_view from implementation detail
   buffer_accessor_view(const array_view_type &access)
     : array { access }
+  {}
+
+
+  //* Make a buffer_accessor_view from storage and sizes
+  buffer_accessor_view(pointer storage, const range<Dimensions> &r)
+    : buffer_accessor_view { array_view_type { storage, r } }
   {}
 
 

--- a/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_accessor_view.hpp
@@ -1,0 +1,348 @@
+#ifndef TRISYCL_SYCL_BUFFER_DETAIL_BUFFER_ACCESSOR_VIEW_HPP
+#define TRISYCL_SYCL_BUFFER_DETAIL_BUFFER_ACCESSOR_VIEW_HPP
+
+/** \file The OpenCL SYCL buffer accessor<> view detail behind the scene
+
+    \todo It is based on Boost MultiArray for now but to move to
+    Kokkos array_view and C++2a
+
+    Ronan at Keryell point FR
+
+    This file is distributed under the University of Illinois Open Source
+    License. See LICENSE.TXT for details.
+*/
+
+#include <cstddef>
+#include <memory>
+
+#include <boost/multi_array.hpp>
+
+#include "CL/sycl/access.hpp"
+#include "CL/sycl/id.hpp"
+#include "CL/sycl/item.hpp"
+#include "CL/sycl/nd_item.hpp"
+
+namespace cl {
+namespace sycl {
+namespace detail {
+
+template <typename T,
+          int Dimensions,
+          access::mode Mode,
+          access::target Target>
+class buffer_accessor_view {
+
+public:
+
+  /// The implementation is a multi_array_ref wrapper
+  using array_view_type = boost::multi_array_ref<T, Dimensions>;
+
+  // The same type but writable
+  using writable_array_view_type =
+    typename std::remove_const<array_view_type>::type;
+
+  /** \todo in the specification: store the dimension for user request
+
+      \todo Use another name, such as from C++2a committee discussions.
+   */
+  static constexpr auto dimensionality = Dimensions;
+
+  //* \todo in the specification: store the mode for user request
+  static constexpr auto mode = Mode;
+
+  //* \todo in the specification: store the target for user request
+  static constexpr auto target = Target;
+
+  /** \todo in the specification: store the types for user request as STL
+      or C++AMP */
+  using value_type = T;
+  using element = T;
+  using reference = typename array_view_type::reference;
+  using const_reference = typename array_view_type::const_reference;
+
+  /** Inherit the iterator types from the implementation
+
+      \todo Add iterators to accessors in the specification
+  */
+  using iterator = typename array_view_type::iterator;
+  using const_iterator = typename array_view_type::const_iterator;
+  using reverse_iterator = typename array_view_type::reverse_iterator;
+  using const_reverse_iterator =
+    typename array_view_type::const_reverse_iterator;
+
+  /** The way the buffer is really accessed
+
+      Use a mutable member because the accessor needs to be captured
+      by value in the lambda which is then read-only. This is to avoid
+      the user to use mutable lambda or have a lot of const_cast as
+      previously done in this implementation
+
+      \todo Remove this mutable
+  */
+  mutable array_view_type array;
+
+  buffer_accessor_view(const array_view_type &access)
+    : array { access }
+  {}
+
+
+  /** Return a range object representing the size of the buffer in
+      terms of number of elements in each dimension as passed to the
+      constructor
+
+      \todo Move on
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
+  */
+  auto get_range() const {
+    /* Interpret the shape which is a pointer to the first element as an
+       array of Dimensions elements so that the range<Dimensions>
+       constructor is happy with this collection
+
+       \todo Add also a constructor in range<> to accept a const
+       std::size_t *?
+    */
+    return range<Dimensions> {
+      *(const std::size_t (*)[Dimensions])(array.shape())
+        };
+  }
+
+
+  /** Returns the total number of elements behind the accessor
+
+      Equal to get_range()[0] * ... * get_range()[Dimensions-1].
+
+      \todo Move on
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
+  */
+  auto get_count() const {
+    return array.num_elements();
+  }
+
+
+  /** Returns the size of the underlying buffer storage in bytes
+
+      \todo Move on
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=15564 and
+      https://cvs.khronos.org/bugzilla/show_bug.cgi?id=14404
+  */
+  auto get_size() const {
+    return get_count()*sizeof(value_type);
+  }
+
+
+  /** Use the accessor with integers à la [][][]
+
+      Use array_view_type::reference instead of auto& because it does not
+      work in some dimensions.
+   */
+  reference operator[](std::size_t index) {
+    return array[index];
+  }
+
+
+  /** Use the accessor with integers à la [][][]
+
+      Use array_view_type::reference instead of auto& because it does not
+      work in some dimensions.
+   */
+  reference operator[](std::size_t index) const {
+    return array[index];
+  }
+
+
+  /// To use the accessor with [id<>]
+  auto &operator[](id<dimensionality> index) {
+    return array(index);
+  }
+
+
+  /// To use the accessor with [id<>]
+  auto &operator[](id<dimensionality> index) const {
+    return array(index);
+  }
+
+
+  /// To use an accessor with [item<>]
+  auto &operator[](item<dimensionality> index) {
+    return (*this)[index.get()];
+  }
+
+
+  /// To use an accessor with [item<>]
+  auto &operator[](item<dimensionality> index) const {
+    return (*this)[index.get()];
+  }
+
+
+  /** To use an accessor with an [nd_item<>]
+
+      \todo Add in the specification because used by HPC-GPU slide 22
+  */
+  auto &operator[](nd_item<dimensionality> index) {
+    return (*this)[index.get_global()];
+  }
+
+  /** To use an accessor with an [nd_item<>]
+
+      \todo Add in the specification because used by HPC-GPU slide 22
+  */
+  auto &operator[](nd_item<dimensionality> index) const {
+    return (*this)[index.get_global()];
+  }
+
+
+  /** Get the first element of the accessor
+
+      Useful with an accessor on a scalar for example.
+
+      \todo Add in the specification
+  */
+  reference operator*() {
+    return *array.data();
+  }
+
+
+  /** Get the first element of the accessor
+
+      Useful with an accessor on a scalar for example.
+
+      \todo Add in the specification?
+
+      \todo Add the concept of 0-dim buffer and accessor for scalar
+      and use an implicit conversion to value_type reference to access
+      the value with the accessor?
+  */
+  reference operator*() const {
+    return *array.data();
+  }
+
+
+  /** Test if the accessor has a read access right
+
+      \todo Strangely, it is not really constexpr because it is not a
+      static method...
+
+      \todo to move in the access::mode enum class and add to the
+      specification ?
+  */
+  constexpr bool is_read_access() const {
+    return Mode == access::mode::read
+      || Mode == access::mode::read_write
+      || Mode == access::mode::discard_read_write;
+  }
+
+
+  /** Test if the accessor has a write access right
+
+      \todo Strangely, it is not really constexpr because it is not a
+      static method...
+
+      \todo to move in the access::mode enum class and add to the
+      specification ?
+  */
+  constexpr bool is_write_access() const {
+    return Mode == access::mode::write
+      || Mode == access::mode::read_write
+      || Mode == access::mode::discard_write
+      || Mode == access::mode::discard_read_write;
+  }
+
+
+  /** Return the pointer to the data
+
+      \todo Implement the various pointer address spaces
+  */
+  auto
+  get_pointer() const {
+    return array.data();
+  }
+
+
+  /** Forward all the iterator functions to the implementation
+
+      \todo Add these functions to the specification
+
+      \todo The fact that the lambda capture make a const copy of the
+      accessor is not yet elegantly managed... The issue is that
+      begin()/end() dispatch is made according to the accessor
+      constness and not from the array member constness...
+
+      \todo try to solve it by using some enable_if on array
+      constness?
+
+      \todo The issue is that the end may not be known if it is
+      implemented by a raw OpenCL cl_mem... So only provide on the
+      device the iterators related to the start? Actually the accessor
+      needs to know a part of the shape to have the multidimentional
+      addressing. So this only require a size_t more...
+
+      \todo Factor out these in a template helper
+
+      \todo Do we need this in detail::accessor too or only in accessor?
+  */
+
+
+  // iterator begin() { return array.begin(); }
+  iterator begin() const {
+    return const_cast<writable_array_view_type &>(array).begin();
+  }
+
+
+  // iterator end() { return array.end(); }
+  iterator end() const {
+    return const_cast<writable_array_view_type &>(array).end();
+  }
+
+
+  // const_iterator begin() const { return array.begin(); }
+
+
+  // const_iterator end() const { return array.end(); }
+
+
+  const_iterator cbegin() const { return array.begin(); }
+
+
+  const_iterator cend() const { return array.end(); }
+
+
+  // reverse_iterator rbegin() { return array.rbegin(); }
+  reverse_iterator rbegin() const {
+    return const_cast<writable_array_view_type &>(array).rbegin();
+  }
+
+
+  // reverse_iterator rend() { return array.rend(); }
+  reverse_iterator rend() const {
+    return const_cast<writable_array_view_type &>(array).rend();
+  }
+
+
+  // const_reverse_iterator rbegin() const { return array.rbegin(); }
+
+
+  // const_reverse_iterator rend() const { return array.rend(); }
+
+
+  const_reverse_iterator crbegin() const { return array.rbegin(); }
+
+
+  const_reverse_iterator crend() const { return array.rend(); }
+
+};
+
+}
+}
+}
+
+/*
+    # Some Emacs stuff:
+    ### Local Variables:
+    ### ispell-local-dictionary: "american"
+    ### eval: (flyspell-prog-mode)
+    ### End:
+*/
+
+#endif // TRISYCL_SYCL_BUFFER_DETAIL_BUFFER_ACCESSOR_VIEW_HPP

--- a/include/CL/sycl/detail/container_element_aspect.hpp
+++ b/include/CL/sycl/detail/container_element_aspect.hpp
@@ -22,6 +22,8 @@ namespace detail {
 template <typename T>
 struct container_element_aspect {
 
+  /** \todo in the specification: store the types for user request as STL
+      or C++AMP */
   using value_type = T;
   using pointer = value_type*;
   using const_pointer = const value_type*;


### PR DESCRIPTION
The current accessor implementation relies on the usual easy detail::shared_ptr_implementation but requires some painful magical Clang rewriting of lambda captures to use drt::accessor instead.
Instead, make a new accessor implementation split in 2 parts, a simple one visible by the device and a heavy shepherd one to manage the accessed resource that will be optimized away by the device compiler in a simpler and natural way.
So make the runtime more complex, but the device compiler simpler.