### PR TITLE
set_final_data overload fix

### DIFF
--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -492,16 +492,17 @@ public:
 
   /** Set destination of buffer data on destruction.
 
-      WARNING: the user has to ensure that the object refered to by the
-      iterator will be alive after buffer destruction, otherwise the behaviour
+      WARNING: the user has to ensure that the object referred to by the
+      iterator will be alive after buffer destruction, otherwise the behavior
       is undefined.
    */
   template <typename Iterator,
-            typename ValueType =
-            typename std::iterator_traits<Iterator>::value_type>
-  void set_final_data(Iterator&& finalData) {
-    implementation->implementation->
-      set_final_data(std::forward<Iterator>(finalData));
+            typename ValueType = typename std::iterator_traits<
+                                          std::remove_reference_t<Iterator>
+                                          >::value_type>
+  void set_final_data(Iterator &&finalData) {
+    implementation->implementation->set_final_data(
+        std::forward<Iterator>(finalData));
   }
 
 };

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -497,12 +497,12 @@ public:
       is undefined.
    */
   template <typename Iterator,
-            typename ValueType = typename std::iterator_traits<
-                                          std::remove_reference_t<Iterator>
-                                          >::value_type>
+            typename ValueType =
+            typename std::iterator_traits<
+              std::remove_reference_t<Iterator>>::value_type>
   void set_final_data(Iterator &&finalData) {
     implementation->implementation->set_final_data(
-        std::forward<Iterator>(finalData));
+      std::forward<Iterator>(finalData));
   }
 
 };


### PR DESCRIPTION
Fix to something I broke in a prior patch that was causing build/compile 
errors for tests in the SYCLParallelSTL.

Didn't account for the need to remove the reference on the rvalue 
referenced iterator when passed in, so the iterator_traits class could 
not find the value_type member!

One of those little hard to catch move/reference semantic errors.

Also some minor spelling fixes.