### PR TITLE
Fix CMake implicit conversion warning

### DIFF
--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -135,9 +135,9 @@ mark_as_advanced(TRISYCL_TRACE_KERNEL)
 mark_as_advanced(TRISYCL_INCLUDE_DIR)
 
 #triSYCL definitions
-set(CL_SYCL_LANGUAGE_VERSION 121 CACHE VERSION
+set(CL_SYCL_LANGUAGE_VERSION 121 CACHE STRING VERSION
   "Host language version to be used by triSYCL (default is: 121)")
-set(TRISYCL_CL_LANGUAGE_VERSION 121 CACHE VERSION
+set(TRISYCL_CL_LANGUAGE_VERSION 121 CACHE STRING VERSION
   "Device language version to be used by triSYCL (default is: 121)")
 set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Explicit data type must be specified when setting a value into cache in order to avoid implicit conversions that trigger warnings like this:

```
CMake Warning (dev) at cmake/FindTriSYCL.cmake:138 (set):
  implicitly converting 'VERSION' to 'STRING' type.
Call Stack (most recent call first):
  CMakeLists.txt:13 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```