### PR TITLE
Update the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Introduction
 ------------
 
 triSYCL_ is an open source implementation to experiment with
-the specification of the SYCL_ 1.2.1 `C++`_ layer and
+the specification of the SYCL_ `C++`_ layer and
 to give feedback to the Khronos_ Group SYCL_ and OpenCL_ C++ 2.2
 kernel language committees and also to the ISO `C++`_ committee.
 
@@ -48,7 +48,7 @@ this. Xilinx_ is also hiring in this area... :-)
 SYCL
 ----
 
-SYCL_ is a single-source C++14/C++17-based DSEL_ (Domain Specific
+SYCL_ is a single-source modern C++-based DSEL_ (Domain Specific
 Embedded Language) aimed at facilitating the programming of heterogeneous
 accelerators by leveraging the OpenCL_ language and concepts.
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ where you might find more futuristic branches.
 This is provided as is, without any warranty, with the same license as
 LLVM_/Clang_.
 
+There is also a new project about merging the Intel SYCL
+implementation with triSYCL at https://github.com/triSYCL/sycl to give
+a greater user experience.
+
 Technical lead: Ronan at keryell point FR. Developments started first
 at AMD_ and are now mainly funded by Xilinx_.
 

--- a/doc/about-sycl.rst
+++ b/doc/about-sycl.rst
@@ -136,6 +136,10 @@ Some other known implementations:
 - SYCL-GTX, an implementation using some macros to avoid relying on a
   device compiler https://github.com/ProGTX/sycl-gtx
 
+- A mix of triSYCL and Intel SYCL implementation trying to unify 2
+  open-source implementations to expose advantages of both of them
+  https://github.com/triSYCL/sycl
+
 
 Some presentations and publications related to SYCL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/about-sycl.rst
+++ b/doc/about-sycl.rst
@@ -11,10 +11,10 @@ other approaches:
 - SYCL_ is an open standard from Khronos_ with a working committee
   (you can contribute!) and we can expect several implementations
   (commercial or open source) on many platforms soon, ranging from
-  GPU, APU, FPGA, DSP... down to plain CPU;
+  GPU, APU, FPGA, DSP, CGRA, AI/ML accelerators... down to plain CPU;
 
 - it offers a *single-source* `C++`_ programming model that allows
-  taking advantage of the modern C++14/C++17 superpower, unifying both
+  taking advantage of the modern C++20 superpower, unifying both
   the host and accelerator sides. For example it is possible to write
   generic accelerated functions on the accelerators in a terse way by
   using (variadic) templates, meta-programming and generic variadic
@@ -48,6 +48,10 @@ other approaches:
     the host and debugged using the usual tools and use any system (such
     ``<cstdio>`` or ``<iostream>``...) or data libraries (for nice data
     visualization);
+
+  - by lowering some architectural features down to plain CPU C++, you
+    can even debug weird data-race problems with standard tools such
+    as Valgrind/Helgrind, Clang/GCC ThreadSanitizer...
 
   - since the kernel code is `C++`_ code even when run on an accelerator,
     instrumenting the code by using special array classes or overloading
@@ -97,7 +101,7 @@ other approaches:
   (TLS) queues, its own scheduler, etc. atop the limited OpenCL_ stack to
   provide computation and communication overlap in a natural pain-free
   fashion. This relieves the programmer to reorganize her application to
-  work around these limitation, which can be quite a cumbersome work.
+  work around these limitations, which can be quite cumbersome work.
 
 For introduction material on the interest of DSEL_ in this area, look for
 example at these articles:

--- a/doc/about-sycl.rst
+++ b/doc/about-sycl.rst
@@ -126,6 +126,10 @@ Some other known implementations:
   Clang_/LLVM_. It is not open-source but there is a free community version
   https://www.codeplay.com/products/computesuite/computecpp
 
+- Intel SYCL open-source implementation which is in the process of
+  being up-streamed to Clang_/LLVM
+  https://github.com/intel/llvm/tree/sycl
+
 - hipSYCL_, an implementation of SYCL_ over nVidia CUDA_ or AMD HIP_
   https://github.com/illuhad/hipSYCL
 

--- a/doc/about-sycl.rst
+++ b/doc/about-sycl.rst
@@ -35,9 +35,9 @@ other approaches:
 - the exit cost is low since it is *pure* `C++`_ *without any*
   extension or ``#pragma``, by opposition to `C++AMP`_ or OpenMP_ for
   example. Retargeting the SYCL_ classes and functions to use other
-  frameworks such as OpenMP_ 4 or `C++AMP`_ is feasible without
+  frameworks such as OpenMP_ 5, CUDA_ or `C++AMP`_ is feasible without
   rewriting a new compiler for example. This is actually what is done in
-  the `hipSYCL`_ implementation;
+  the `hipSYCL`_ implementation for CUDA_ or HIP_;
 
 - easier debugging
 

--- a/doc/possible-futures.rst
+++ b/doc/possible-futures.rst
@@ -45,7 +45,7 @@ Some ideas of future developments where *you* can contribute too: :-)
 - since SYCL_ is a pretty general programming model for heterogeneous
   computing, if the OpenCL_ compatibility layer is not required, some other
   back-ends could be written besides the current OpenMP_ one: CUDA_,
-  RenderScript_, OpenAMP_, etc.
+  RenderScript_, OpenAMP_, etc. Actually this is the base for hipSYCL_
 
 - make an alternative accelerator version based on OpenMP_ 5
   accelerator target, OpenHMPP_ or OpenACC_;
@@ -97,6 +97,10 @@ Some ideas of future developments where *you* can contribute too: :-)
 .. _GOOPAX: http://www.goopax.com/
 
 .. _HCC: https://github.com/RadeonOpenCompute/hcc
+
+.. _HIP: https://github.com/ROCm-Developer-Tools/HIP
+
+.. _hipSYCL: https://github.com/illuhad/hipSYCL
 
 .. _HSA: http://www.hsafoundation.com/
 

--- a/doc/possible-futures.rst
+++ b/doc/possible-futures.rst
@@ -10,7 +10,8 @@ https://gitenterprise.xilinx.com/rkeryell/triSYCL/issues
 
 Some ideas of future developments where *you* can contribute too: :-)
 
-- go on using the official OpenCL_ SYCL_ conformance test suite (CTS) to
+- go on using the official OpenCL_ SYCL_ conformance test suite (CTS)
+  which is now open-source https://github.com/KhronosGroup/SYCL-CTS to
   extend/debug/validate this implementation;
 
 - finish implementation of basic classes without any OpenCL_ support

--- a/doc/possible-futures.rst
+++ b/doc/possible-futures.rst
@@ -57,7 +57,12 @@ Some ideas of future developments where *you* can contribute too: :-)
 - SYCL_ concepts (well, classes) can also be ported to some other
   languages to provide heterogeneous support: SYJSCL, SYCamlCL,
   SYJavaCL... It is not clear yet if SYFortranCL is possible with
-  Fortran 2008 or 2015+.
+  Fortran 2008 or 2015+;
+
+- some of the proposed extensions above are actually on-going is some
+  other projects or in the fusion of Intel SYCL and triSYCL
+  https://github.com/triSYCL/sycl
+
 
 .. Some useful link definitions:
 

--- a/doc/possible-futures.rst
+++ b/doc/possible-futures.rst
@@ -29,7 +29,7 @@ Some ideas of future developments where *you* can contribute too: :-)
 
 - update the dataflow SYCL infrastructure from plain C++ ``std::thread``
   and ``std::condition_variable`` to some more efficient library, such
-  as TBB_;
+  as TBB_ or `Boost.Fiber <https://github.com/boostorg/fiber>`_;
 
 - implement the dataflow SYCL infrastructure directly on top of OpenCL
   event-framework instead of layering the CPU dataflow dependency
@@ -40,14 +40,14 @@ Some ideas of future developments where *you* can contribute too: :-)
   http://jojendersie.de/performance-optimal-vector-swizzling-in-c
   http://www.reedbeta.com/blog/2013/12/28/on-vector-math-libraries ;
 
-- add OpenCL_ 2.x support with SYCL_ 2.x;
+- add OpenCL_ 2.x support;
 
 - since SYCL_ is a pretty general programming model for heterogeneous
   computing, if the OpenCL_ compatibility layer is not required, some other
   back-ends could be written besides the current OpenMP_ one: CUDA_,
   RenderScript_, OpenAMP_, etc.
 
-- make an alternative accelerator version based on OpenMP_ 4
+- make an alternative accelerator version based on OpenMP_ 5
   accelerator target, OpenHMPP_ or OpenACC_;
 
 - make an alternative accelerator version based on wrapper classes for


### PR DESCRIPTION
Modernize descriptions.
More content about hipSYCL project and CUDA.
The Khronos SYCL CTS is now open-source.
Add link to Intel SYCL open-source implementation.
Add link to triSYCL + Intel SYCL fusion .