### PR TITLE
C++17 nested namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN git clone https://github.com/${git_slug}.git -b ${git_branch} /trisycl
 
 RUN cd /trisycl; cmake . -DTRISYCL_OPENCL=${opencl}                            \
     -DTRISYCL_OPENMP=${openmp} -DCMAKE_C_COMPILER=${c_compiler}                \
-    -DCMAKE_CXX_COMPILER=${cxx_compiler} && make -j 4
+    -DCMAKE_CXX_COMPILER=${cxx_compiler} && make -j`nproc`
 
-CMD cd /trisycl && make -j 2 && ctest
+CMD cd /trisycl && make -j`nproc` && ctest

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -203,8 +203,8 @@ Then compile for example with::
     -DLLVM_BUILD_LLVM_DYLIB:BOOL=ON \
     -DLLVM_LINK_LLVM_DYLIB:BOOL=ON \
     ../llvm
-  # Use -j8 to speed up compilation if you have 8 cores for example
-  make -j8
+  # Use -j with 1 thread per core to speed up compilation
+  make -j`nproc`
 
 You might replace the ``Release`` by ``Debug`` above if you want to
 debug the compiler itself. Look at https://llvm.org/docs/CMake.html

--- a/doc/cmake.rst
+++ b/doc/cmake.rst
@@ -36,7 +36,9 @@ To compile the tests with OpenCL, use for example on Unix::
   mkdir build
   cd build
   cmake .. -DTRISYCL_OPENCL=ON
-  make -j
+  # Use as many compilation threads as we have CPU cores
+  # but it might be dangerous if there is not enough memory per core
+  make -j`nproc`
 
 Notes
 `````
@@ -60,7 +62,7 @@ LIT, can test exit codes and match stdout vs. a regex.
 
 To run the tests once compiled, use for example::
 
-  ctest -j
+  ctest
 
 
 Warning-free

--- a/doc/cmake.rst
+++ b/doc/cmake.rst
@@ -40,6 +40,12 @@ To compile the tests with OpenCL, use for example on Unix::
   # but it might be dangerous if there is not enough memory per core
   make -j`nproc`
 
+Adding the option ``-DCMAKE_EXPORT_COMPILE_COMMANDS=1`` to the CMake
+parameter is useful to generate the compilation database used by some
+tools such as the Clang-based indexing and refactoring tools
+(``run-clang-tidy``...).
+
+
 Notes
 `````
 

--- a/include/CL/sycl/access.hpp
+++ b/include/CL/sycl/access.hpp
@@ -10,8 +10,7 @@
 */
 
 // SYCL dwells in the cl::sycl namespace
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
 
@@ -70,7 +69,6 @@ namespace access {
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/accessor.hpp
+++ b/include/CL/sycl/accessor.hpp
@@ -22,8 +22,7 @@
 #include "CL/sycl/pipe_reservation.hpp"
 #include "CL/sycl/pipe/detail/pipe_accessor.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <typename T, int Dimensions, typename Allocator>
 class buffer;
@@ -491,7 +490,6 @@ static inline auto &get_pipe_detail(Accessor &a) {
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/accessor/detail/accessor_base.hpp
+++ b/include/CL/sycl/accessor/detail/accessor_base.hpp
@@ -20,8 +20,7 @@
 #include "CL/sycl/command_group/detail/task.hpp"
 #include "CL/sycl/detail/debug.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -72,7 +71,6 @@ public:
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/accessor/detail/local_accessor.hpp
+++ b/include/CL/sycl/accessor/detail/local_accessor.hpp
@@ -24,8 +24,7 @@
 #include "CL/sycl/item.hpp"
 #include "CL/sycl/nd_item.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -383,7 +382,6 @@ private:
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/address_space.hpp
+++ b/include/CL/sycl/address_space.hpp
@@ -16,14 +16,14 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup address_spaces Dealing with OpenCL address spaces
     @{
 */
 
 namespace access {
+
 /** Enumerate the different OpenCL 2 address spaces */
 enum class address_space {
   global_space,
@@ -34,16 +34,13 @@ enum class address_space {
 };
 
 }
-}
-}
 /// @} End the address_spaces Doxygen group
-
+}
 
 #include "CL/sycl/address_space/detail/address_space.hpp"
 
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup address_spaces
     @{
@@ -154,8 +151,7 @@ multi_ptr<T, AS> make_ptr(T *pointer) {
   return pointer;
 }
 }
-}
-/// @} End the parallelism Doxygen group
+/// @} End the address_spaces Doxygen group
 
 /*
     # Some Emacs stuff:

--- a/include/CL/sycl/address_space/detail/address_space.hpp
+++ b/include/CL/sycl/address_space/detail/address_space.hpp
@@ -49,9 +49,7 @@
 #define TRISYCL_PRIVATE_AS
 
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup address_spaces
     @{
@@ -388,8 +386,6 @@ struct address_space_object : public ocl_type<T, AS>::type,
 
 /// @} End the address_spaces Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/allocator.hpp
+++ b/include/CL/sycl/allocator.hpp
@@ -11,8 +11,7 @@
 
 #include <memory>
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -51,7 +50,6 @@ using map_allocator = std::allocator<T>;
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/buffer.hpp
+++ b/include/CL/sycl/buffer.hpp
@@ -27,8 +27,7 @@
 #include "CL/sycl/queue.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -509,7 +508,6 @@ public:
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /* Inject a custom specialization of std::hash to have the buffer

--- a/include/CL/sycl/buffer/detail/accessor.hpp
+++ b/include/CL/sycl/buffer/detail/accessor.hpp
@@ -25,8 +25,7 @@
 #include "CL/sycl/item.hpp"
 #include "CL/sycl/nd_item.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -488,7 +487,6 @@ private:
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/buffer/detail/buffer.hpp
+++ b/include/CL/sycl/buffer/detail/buffer.hpp
@@ -23,9 +23,7 @@
 #include "CL/sycl/buffer/detail/buffer_waiter.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 
 /** \addtogroup data Data access and storage in SYCL
@@ -434,8 +432,6 @@ buffer_add_to_task(BufferDetail buf,
 
 /// @} End the data Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/buffer/detail/buffer_base.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_base.hpp
@@ -26,8 +26,7 @@
 #include "CL/sycl/command_group/detail/task.hpp"
 #include "CL/sycl/context.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -320,7 +319,6 @@ struct buffer_base : public std::enable_shared_from_this<buffer_base> {
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/buffer/detail/buffer_waiter.hpp
+++ b/include/CL/sycl/buffer/detail/buffer_waiter.hpp
@@ -16,9 +16,7 @@
 #include "CL/sycl/buffer_allocator.hpp"
 #include "CL/sycl/detail/shared_ptr_implementation.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -82,8 +80,6 @@ inline auto waiter(detail::buffer<T, Dimensions> *b) {
 
 /// @} End the data Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/buffer_allocator.hpp
+++ b/include/CL/sycl/buffer_allocator.hpp
@@ -12,8 +12,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -29,7 +28,6 @@ using buffer_allocator = std::allocator<T>;
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/command_group/detail/task.hpp
+++ b/include/CL/sycl/command_group/detail/task.hpp
@@ -25,9 +25,7 @@
 #include "CL/sycl/kernel.hpp"
 #include "CL/sycl/queue/detail/queue.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** The abstraction to represent SYCL tasks executing inside command_group
 
@@ -312,8 +310,6 @@ std::size_t register_accessor(std::weak_ptr<detail::accessor_base> a) {
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/context.hpp
+++ b/include/CL/sycl/context.hpp
@@ -24,8 +24,7 @@
 #include "CL/sycl/info/context.hpp"
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -228,7 +227,6 @@ inline auto context::get_info<info::context::devices>() const {
 
 /// @} to end the execution Doxygen group
 
-}
 }
 
 namespace std {

--- a/include/CL/sycl/context/detail/context.hpp
+++ b/include/CL/sycl/context/detail/context.hpp
@@ -13,9 +13,7 @@
 #include "CL/sycl/platform.hpp"
 #include "CL/sycl/detail/default_classes.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
   /** \addtogroup execution Platforms, contexts, devices and queues
       @{
@@ -64,8 +62,6 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/context/detail/context_tail.hpp
+++ b/include/CL/sycl/context/detail/context_tail.hpp
@@ -11,15 +11,13 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /* has to be inline as it references default_selector */
 inline context::context(const vector_class<device> &deviceList,
 			async_handler asyncHandler)
   : context(deviceList, asyncHandler, default_selector {}) {}
 
-}
 }
 /*
     # Some Emacs stuff:

--- a/include/CL/sycl/context/detail/host_context.hpp
+++ b/include/CL/sycl/context/detail/host_context.hpp
@@ -17,9 +17,7 @@
 #include "CL/sycl/info/platform.hpp"
 #include "CL/sycl/context/detail/context.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 
 /** \addtogroup execution Platforms, contexts, devices and queues
@@ -117,7 +115,5 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
-}
 }
 #endif // TRISYCL_SYCL_CONTEXT_DETAIL_HOST_CONTEXT_HPP

--- a/include/CL/sycl/context/detail/opencl_context.hpp
+++ b/include/CL/sycl/context/detail/opencl_context.hpp
@@ -22,9 +22,7 @@
 #include "CL/sycl/exception.hpp"
 
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /// SYCL OpenCL context
 class opencl_context : public detail::context {
@@ -147,8 +145,6 @@ TRISYCL_WEAK_ATTRIB_PREFIX
 detail::cache<cl_context, detail::opencl_context> opencl_context::cache
 TRISYCL_WEAK_ATTRIB_SUFFIX;
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/array_tuple_helpers.hpp
+++ b/include/CL/sycl/detail/array_tuple_helpers.hpp
@@ -16,9 +16,7 @@
 #include <tuple>
 #include <utility>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup array_tuple_helpers Helpers to do array and tuple conversion
 
@@ -129,8 +127,6 @@ auto expand(Tuple t) {
                            std::tuple_size<Tuple>::value == 1>{}.expand(t));
 }
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/cache.hpp
+++ b/include/CL/sycl/detail/cache.hpp
@@ -13,9 +13,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 
 /** A simple thread safe cache mechanism to cache std::shared_ptr of
@@ -88,8 +86,6 @@ public:
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/container_element_aspect.hpp
+++ b/include/CL/sycl/detail/container_element_aspect.hpp
@@ -10,9 +10,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup helpers Some helpers for the implementation
     @{
@@ -32,8 +30,6 @@ struct container_element_aspect {
 
 /// @} End the helpers Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/debug.hpp
+++ b/include/CL/sycl/detail/debug.hpp
@@ -51,9 +51,7 @@ using namespace std::string_literals;
 #define TRISYCL_DUMP_T(expression) do { } while(0)
 #endif
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup debug_trace Debugging and tracing support
     @{
@@ -174,8 +172,6 @@ struct display_vector {
 
 /// @} End the debug_trace Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/default_classes.hpp
+++ b/include/CL/sycl/detail/default_classes.hpp
@@ -19,13 +19,11 @@
  */
 #include <memory>
 #include <vector>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class T, class Alloc = std::allocator<T>>
 using vector_class = std::vector<T, Alloc>;
 
-}
 }
 #endif
 
@@ -34,12 +32,10 @@ using vector_class = std::vector<T, Alloc>;
 /** The string type to be used as SYCL string
  */
 #include <string>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 using string_class = std::string;
 
-}
 }
 #endif
 
@@ -48,13 +44,11 @@ using string_class = std::string;
 /** The functional type to be used as SYCL function
  */
 #include <functional>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class R, class... ArgTypes>
 using function_class = std::function<R(ArgTypes...)>;
 
-}
 }
 #endif
 
@@ -63,12 +57,10 @@ using function_class = std::function<R(ArgTypes...)>;
 /** The mutex type to be used as SYCL mutex
  */
 #include <mutex>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 using mutex_class = std::mutex;
 
-}
 }
 #endif
 
@@ -77,13 +69,11 @@ using mutex_class = std::mutex;
 /** The unique pointer type to be used as SYCL unique pointer
  */
 #include <memory>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class T, class D = std::default_delete<T>>
 using unique_ptr_class = std::unique_ptr<T[], D>;
 
-}
 }
 #endif
 
@@ -92,13 +82,11 @@ using unique_ptr_class = std::unique_ptr<T[], D>;
 /** The shared pointer type to be used as SYCL shared pointer
  */
 #include <memory>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class T>
 using shared_ptr_class = std::shared_ptr<T>;
 
-}
 }
 #endif
 
@@ -107,13 +95,11 @@ using shared_ptr_class = std::shared_ptr<T>;
 /** The weak pointer type to be used as SYCL weak pointer
  */
 #include <memory>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class T>
 using weak_ptr_class = std::weak_ptr<T>;
 
-}
 }
 #endif
 
@@ -122,13 +108,11 @@ using weak_ptr_class = std::weak_ptr<T>;
 /** The hash type to be used as SYCL hash
  */
 #include <functional>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <class T>
 using hash_class = std::hash<T>;
 
-}
 }
 #endif
 
@@ -137,12 +121,10 @@ using hash_class = std::hash<T>;
 /** The exception pointer type to be used as SYCL exception pointer
  */
 #include <exception>
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 using exception_ptr_class = std::exception_ptr;
 
-}
 }
 #endif
 

--- a/include/CL/sycl/detail/instantiate_kernel.hpp
+++ b/include/CL/sycl/detail/instantiate_kernel.hpp
@@ -17,9 +17,7 @@
 
 #include "CL/sycl/command_group/detail/task.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** Avoid the interprocedural optimization to remove these arguments
     in the kernel instantiation by relying on some dummy static variables.
@@ -108,8 +106,6 @@ void launch_device_kernel(detail::task &t,
   instantiate_kernel<KernelName>(k);
 }
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/linear_id.hpp
+++ b/include/CL/sycl/detail/linear_id.hpp
@@ -11,9 +11,7 @@
 
 #include <cstddef>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup helpers Some helpers for the implementation
     @{
@@ -41,8 +39,6 @@ size_t constexpr inline linear_id(Range range, Id id, Id offset = {}) {
 
 /// @} End the helpers Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/shared_ptr_implementation.hpp
+++ b/include/CL/sycl/detail/shared_ptr_implementation.hpp
@@ -16,9 +16,7 @@
 
 #include <boost/operators.hpp>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** Provide an implementation as shared_ptr with total ordering and
     hashing to be used with algorithms and in (un)ordered containers
@@ -86,8 +84,6 @@ struct shared_ptr_implementation : public boost::totally_ordered<Parent> {
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/singleton.hpp
+++ b/include/CL/sycl/detail/singleton.hpp
@@ -16,9 +16,7 @@
 #include <boost/operators.hpp>
 
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /// Provide a singleton factory
 template <typename T>
@@ -38,8 +36,6 @@ struct singleton {
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/small_array.hpp
+++ b/include/CL/sycl/detail/small_array.hpp
@@ -19,9 +19,7 @@
 #include "CL/sycl/detail/debug.hpp"
 
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup helpers Some helpers for the implementation
     @{
@@ -353,8 +351,6 @@ struct small_array_123<BasicType, FinalType, 3>
 
 /// @} End the helpers Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/detail/unimplemented.hpp
+++ b/include/CL/sycl/detail/unimplemented.hpp
@@ -10,9 +10,7 @@
 
 #include <iostream>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup helpers Some helpers for the implementation
     @{
@@ -34,8 +32,6 @@ inline void unimplemented(const char *func, const char *file, int line) {
 #define TRISYCL_UNIMPL cl::sycl::detail::unimplemented(__func__, __FILE__, __LINE__)
 /// @} End the helpers Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/device.hpp
+++ b/include/CL/sycl/device.hpp
@@ -30,8 +30,7 @@
 #include "CL/sycl/opencl_types.hpp"
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class device_selector;
 class platform;
@@ -254,7 +253,6 @@ public:
 
 /// @} to end the Doxygen group
 
-}
 }
 
 

--- a/include/CL/sycl/device/detail/device.hpp
+++ b/include/CL/sycl/device/detail/device.hpp
@@ -13,9 +13,7 @@
 
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -70,8 +68,6 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/device/detail/device_tail.hpp
+++ b/include/CL/sycl/device/detail/device_tail.hpp
@@ -11,8 +11,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -45,7 +44,6 @@ device::get_devices(info::device_type device_type) {
 
 /// @} to end the Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/device/detail/host_device.hpp
+++ b/include/CL/sycl/device/detail/host_device.hpp
@@ -20,9 +20,7 @@
 #include "CL/sycl/info/param_traits.hpp"
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** SYCL host device
 
@@ -126,8 +124,6 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/device/detail/opencl_device.hpp
+++ b/include/CL/sycl/device/detail/opencl_device.hpp
@@ -22,9 +22,7 @@
 #include "CL/sycl/info/param_traits.hpp"
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /// SYCL OpenCL device
 class opencl_device : public detail::device {
@@ -132,8 +130,6 @@ TRISYCL_WEAK_ATTRIB_PREFIX
 detail::cache<cl_device_id, detail::opencl_device> opencl_device::cache
 TRISYCL_WEAK_ATTRIB_SUFFIX;
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/device_runtime.hpp
+++ b/include/CL/sycl/device_runtime.hpp
@@ -38,9 +38,7 @@
 #include "CL/sycl/device_selector.hpp"
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
-
+namespace cl::sycl::drt {
 /** \addtogroup device_runtime Device-side runtime implementation
     @{
 */
@@ -227,7 +225,6 @@ set_kernel(detail::task &task,
 
 /// @} to end the Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/device_selector.hpp
+++ b/include/CL/sycl/device_selector.hpp
@@ -9,8 +9,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -50,7 +49,6 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/device_selector/detail/device_selector_tail.hpp
+++ b/include/CL/sycl/device_selector/detail/device_selector_tail.hpp
@@ -17,8 +17,7 @@
 #include <boost/compute.hpp>
 #endif
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -165,7 +164,6 @@ using host_selector = device_typename_selector<info::device_type::host>;
 
 /// @} to end the execution Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/error_handler.hpp
+++ b/include/CL/sycl/error_handler.hpp
@@ -11,8 +11,7 @@
 
 #include "CL/sycl/exception.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup error_handling Error handling
     @{
@@ -62,7 +61,6 @@ namespace trisycl {
 
 /// @} End the error_handling Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/exception.hpp
+++ b/include/CL/sycl/exception.hpp
@@ -11,8 +11,7 @@
 
 #include <exception>
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup error_handling Error handling
     @{
@@ -206,7 +205,6 @@ class non_cl_error : public runtime_error {
 
 /// @} End the error_handling Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/group.hpp
+++ b/include/CL/sycl/group.hpp
@@ -18,8 +18,7 @@
 #include "CL/sycl/nd_range.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <int Dimensions = 1>
 struct group;
@@ -192,7 +191,6 @@ public:
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/h_item.hpp
+++ b/include/CL/sycl/h_item.hpp
@@ -19,8 +19,7 @@
 #include "CL/sycl/nd_range.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
@@ -237,7 +236,6 @@ public:
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/half.hpp
+++ b/include/CL/sycl/half.hpp
@@ -7,8 +7,7 @@
  */
 
 /* Dummy half implementation - this is enough to get the CTS to build. */
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class half {
 public:
@@ -16,8 +15,6 @@ public:
 
   bool operator>(const half &h1) { return false; };
 };
-
-}
 
 }
 

--- a/include/CL/sycl/handler.hpp
+++ b/include/CL/sycl/handler.hpp
@@ -28,8 +28,7 @@
 #include "CL/sycl/parallelism.hpp"
 #include "CL/sycl/queue/detail/queue.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -514,7 +513,6 @@ add_buffer_to_task(handler *command_group_handler,
 
 /// @} End the execution Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/id.hpp
+++ b/include/CL/sycl/id.hpp
@@ -15,8 +15,7 @@
 #include "CL/sycl/detail/small_array.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 template <int Dimensions, bool with_offset> class item;
 
@@ -86,7 +85,6 @@ auto make_id(BasicType... Args) {
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/image.hpp
+++ b/include/CL/sycl/image.hpp
@@ -11,8 +11,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data
 
@@ -26,7 +25,6 @@ template <int Dimensions> struct image;
 /// @} End the data Doxygen group
 
 
-}
 }
 
 /*

--- a/include/CL/sycl/info/context.hpp
+++ b/include/CL/sycl/info/context.hpp
@@ -11,8 +11,7 @@
 
 #include "CL/sycl/info/param_traits.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -38,7 +37,6 @@ TRISYCL_INFO_PARAM_TRAITS_ANY_T(info::context, void)
 TRISYCL_INFO_PARAM_TRAITS(info::context::reference_count, cl::sycl::cl_uint)
 TRISYCL_INFO_PARAM_TRAITS(info::context::platform, cl::sycl::platform)
 TRISYCL_INFO_PARAM_TRAITS(info::context::devices, vector_class<cl::sycl::device>)
-}
 }
 }
 

--- a/include/CL/sycl/info/device.hpp
+++ b/include/CL/sycl/info/device.hpp
@@ -13,8 +13,7 @@
 #include "CL/sycl/opencl_types.hpp"
 #include "CL/sycl/info/param_traits.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class device;
 class platform;
@@ -265,7 +264,6 @@ TRISYCL_INFO_PARAM_TRAITS(info::device::partition_affinity_domains, vector_class
 TRISYCL_INFO_PARAM_TRAITS(info::device::partition_type_property, partition_property)
 TRISYCL_INFO_PARAM_TRAITS(info::device::partition_type_affinity_domain, partition_affinity_domain)
 TRISYCL_INFO_PARAM_TRAITS(info::device::reference_count, cl::sycl::cl_uint)
-}
 }
 }
 

--- a/include/CL/sycl/info/param_traits.hpp
+++ b/include/CL/sycl/info/param_traits.hpp
@@ -9,9 +9,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
-namespace info {
+namespace cl::sycl::info {
 
 /** Implement a meta-function from (T, value) to T' to express the return type
     value of an OpenCL function of kind (T, value)
@@ -39,8 +37,6 @@ struct param_traits {
     using return_type = RETURN_TYPE;                        \
   };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/info/platform.hpp
+++ b/include/CL/sycl/info/platform.hpp
@@ -12,8 +12,7 @@
 #include "CL/sycl/detail/global_config.hpp"
 #include "CL/sycl/info/param_traits.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -85,7 +84,6 @@ TRISYCL_INFO_PARAM_TRAITS(info::platform::host_timer_resolution,
                           unsigned long int)
 #endif
 #endif
-}
 }
 }
 

--- a/include/CL/sycl/item.hpp
+++ b/include/CL/sycl/item.hpp
@@ -15,8 +15,7 @@
 #include "CL/sycl/id.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
@@ -140,7 +139,6 @@ public:
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/kernel.hpp
+++ b/include/CL/sycl/kernel.hpp
@@ -22,8 +22,7 @@
 #include "CL/sycl/kernel/detail/opencl_kernel.hpp"
 #endif
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -111,7 +110,6 @@ class kernel
 
 /// @} End the execution Doxygen group
 
-}
 }
 
 

--- a/include/CL/sycl/kernel/detail/kernel.hpp
+++ b/include/CL/sycl/kernel/detail/kernel.hpp
@@ -19,9 +19,7 @@
 #include "CL/sycl/queue/detail/queue.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -83,8 +81,6 @@ class kernel : detail::debug<detail::kernel> {
 
 /// @} End the execution Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/kernel/detail/opencl_kernel.hpp
+++ b/include/CL/sycl/kernel/detail/opencl_kernel.hpp
@@ -21,9 +21,7 @@
 #include "CL/sycl/queue/detail/queue.hpp"
 
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /// An abstraction of the OpenCL kernel
 class opencl_kernel : public detail::kernel,
@@ -144,8 +142,6 @@ TRISYCL_WEAK_ATTRIB_PREFIX
 detail::cache<cl_kernel, detail::opencl_kernel> opencl_kernel::cache
 TRISYCL_WEAK_ATTRIB_SUFFIX;
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/nd_item.hpp
+++ b/include/CL/sycl/nd_item.hpp
@@ -19,8 +19,7 @@
 #include "CL/sycl/nd_range.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
@@ -230,7 +229,6 @@ public:
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/nd_range.hpp
+++ b/include/CL/sycl/nd_range.hpp
@@ -14,8 +14,7 @@
 #include "CL/sycl/id.hpp"
 #include "CL/sycl/range.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
@@ -92,7 +91,6 @@ public:
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/opencl_types.hpp
+++ b/include/CL/sycl/opencl_types.hpp
@@ -29,8 +29,7 @@
 #endif
 
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 // List of the cl_types that will be iterated upon to generate the vector types
 #define TRISYCL_SCALAR_TYPES                                                    \
@@ -179,7 +178,6 @@ template <> struct is_wrapper<type> : std::true_type {};
 // Generate the vector types for all listed scalar types
 BOOST_PP_LIST_FOR_EACH(TRISYCL_DECLARE_CL_TYPES, _, TRISYCL_SCALAR_TYPES)
 
-} // sycl
 } // cl
 
 

--- a/include/CL/sycl/parallelism/detail/parallelism.hpp
+++ b/include/CL/sycl/parallelism/detail/parallelism.hpp
@@ -37,9 +37,7 @@
     @{
 */
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 
 /** A recursive multi-dimensional iterator that ends up calling f
@@ -466,8 +464,6 @@ void parallel_for_workitem_in_group(const group<Dimensions> &g,
 
 /// @} End the parallelism Doxygen group
 
-} // namespace detail
-}
 }
 
 /*

--- a/include/CL/sycl/pipe.hpp
+++ b/include/CL/sycl/pipe.hpp
@@ -17,8 +17,7 @@
 #include "CL/sycl/handler.hpp"
 #include "CL/sycl/pipe/detail/pipe.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -88,7 +87,6 @@ public:
 
 /// @} End the execution Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/pipe/detail/pipe.hpp
+++ b/include/CL/sycl/pipe/detail/pipe.hpp
@@ -27,9 +27,7 @@
 #endif
 #include <boost/circular_buffer.hpp>
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -494,8 +492,6 @@ public:
 
 /// @} End the execution Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/pipe/detail/pipe_accessor.hpp
+++ b/include/CL/sycl/pipe/detail/pipe_accessor.hpp
@@ -18,8 +18,7 @@
 #include "CL/sycl/pipe/detail/pipe.hpp"
 #include "CL/sycl/pipe_reservation/detail/pipe_reservation.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class handler;
 
@@ -289,7 +288,6 @@ public:
 
 /// @} End the data Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/pipe_reservation.hpp
+++ b/include/CL/sycl/pipe_reservation.hpp
@@ -15,8 +15,7 @@
 
 #include "CL/sycl/pipe_reservation/detail/pipe_reservation.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -169,7 +168,6 @@ struct pipe_reservation {
 
 /// @} End the data Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/pipe_reservation/detail/pipe_reservation.hpp
+++ b/include/CL/sycl/pipe_reservation/detail/pipe_reservation.hpp
@@ -14,9 +14,7 @@
 
 #include "CL/sycl/pipe/detail/pipe.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 template <typename T,
           int Dimensions,
@@ -190,8 +188,6 @@ public:
 
 /// @} End the data Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/platform.hpp
+++ b/include/CL/sycl/platform.hpp
@@ -24,8 +24,7 @@
 #endif
 #include "CL/sycl/platform/detail/platform.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class device_selector;
 class device;
@@ -177,7 +176,6 @@ PLATFORM_GET_INFO_STRING(vendor)
 
 /// @} to end the execution Doxygen group
 
-}
 }
 
 

--- a/include/CL/sycl/platform/detail/host_platform_tail.hpp
+++ b/include/CL/sycl/platform/detail/host_platform_tail.hpp
@@ -11,9 +11,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -42,8 +40,6 @@ inline host_platform::get_devices(const device_selector &device_selector) const 
 
 /// @} to end the Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/platform/detail/opencl_platform.hpp
+++ b/include/CL/sycl/platform/detail/opencl_platform.hpp
@@ -20,8 +20,7 @@
 #include "CL/sycl/info/param_traits.hpp"
 #include "CL/sycl/platform/detail/platform.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class device;
 
@@ -126,7 +125,6 @@ TRISYCL_WEAK_ATTRIB_SUFFIX;
 
 /// @} to end the execution Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/platform/detail/opencl_platform_tail.hpp
+++ b/include/CL/sycl/platform/detail/opencl_platform_tail.hpp
@@ -11,9 +11,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** \addtogroup execution Platforms, contexts, devices and queues
     @{
@@ -48,8 +46,6 @@ inline opencl_platform::get_devices(const device_selector &device_selector) cons
 
 /// @} to end the Doxygen group
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/platform/detail/platform.hpp
+++ b/include/CL/sycl/platform/detail/platform.hpp
@@ -13,8 +13,7 @@
 
 #include "CL/sycl/platform.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class device;
 class device_selector;
@@ -68,7 +67,6 @@ public:
 
 /// @} to end the execution Doxygen group
 
-}
 }
 }
 

--- a/include/CL/sycl/platform/detail/platform_tail.hpp
+++ b/include/CL/sycl/platform/detail/platform_tail.hpp
@@ -8,8 +8,7 @@
     License. See LICENSE.TXT for details.
 */
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 inline
 platform::platform(const device_selector &device_selector) {
@@ -34,7 +33,6 @@ platform::get_devices(info::device_type device_type) const {
   return implementation->get_devices(device_type_selector { device_type });
 }
 
-}
 }
 
 #endif

--- a/include/CL/sycl/program.hpp
+++ b/include/CL/sycl/program.hpp
@@ -19,8 +19,7 @@
 #include "CL/sycl/kernel.hpp"
 #include "CL/sycl/program/detail/program.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 enum class program_state {
   none,
@@ -87,8 +86,6 @@ class program
   }
 #endif
 };
-
-}
 
 }
 

--- a/include/CL/sycl/program/detail/program.hpp
+++ b/include/CL/sycl/program/detail/program.hpp
@@ -15,9 +15,7 @@
 #include "CL/sycl/detail/debug.hpp"
 #include "CL/sycl/detail/unimplemented.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 class program : detail::debug<detail::program> {
 
@@ -35,8 +33,6 @@ class program : detail::debug<detail::program> {
   virtual ~program() {}
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/queue.hpp
+++ b/include/CL/sycl/queue.hpp
@@ -33,8 +33,7 @@
 #include "CL/sycl/queue/detail/opencl_queue.hpp"
 #endif
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 class context;
 class device_selector;
@@ -374,7 +373,6 @@ inline auto queue::get_info<info::queue::reference_count>() const {
 }
 /// @} to end the execution Doxygen group
 
-}
 }
 
 /* Inject a custom specialization of std::hash to have the buffer

--- a/include/CL/sycl/queue/detail/host_queue.hpp
+++ b/include/CL/sycl/queue/detail/host_queue.hpp
@@ -18,9 +18,7 @@
 #include "CL/sycl/device.hpp"
 #include "CL/sycl/queue/detail/queue.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** Some implementation details about the SYCL queue
 
@@ -75,8 +73,6 @@ class host_queue : public detail::queue,
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/queue/detail/opencl_queue.hpp
+++ b/include/CL/sycl/queue/detail/opencl_queue.hpp
@@ -15,9 +15,7 @@
 #include "CL/sycl/device.hpp"
 #include "CL/sycl/queue/detail/queue.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /// Some implementation details about the SYCL queue
 class opencl_queue : public detail::queue,
@@ -107,8 +105,6 @@ TRISYCL_WEAK_ATTRIB_PREFIX
 detail::cache<cl_command_queue, detail::opencl_queue> opencl_queue::cache
 TRISYCL_WEAK_ATTRIB_SUFFIX;
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/queue/detail/queue.hpp
+++ b/include/CL/sycl/queue/detail/queue.hpp
@@ -21,9 +21,7 @@
 #include "CL/sycl/device.hpp"
 #include "CL/sycl/detail/debug.hpp"
 
-namespace cl {
-namespace sycl {
-namespace detail {
+namespace cl::sycl::detail {
 
 /** Some implementation details about the SYCL queue
  */
@@ -123,8 +121,6 @@ struct queue : detail::debug<detail::queue> {
 
 };
 
-}
-}
 }
 
 /*

--- a/include/CL/sycl/range.hpp
+++ b/include/CL/sycl/range.hpp
@@ -13,8 +13,7 @@
 #include <numeric>
 #include "CL/sycl/detail/small_array.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup parallelism Expressing parallelism through kernels
     @{
@@ -78,7 +77,6 @@ auto make_range(BasicType... Args) {
 
 /// @} End the parallelism Doxygen group
 
-}
 }
 
 /*

--- a/include/CL/sycl/static_pipe.hpp
+++ b/include/CL/sycl/static_pipe.hpp
@@ -18,8 +18,7 @@
 #include "CL/sycl/handler.hpp"
 #include "CL/sycl/pipe/detail/pipe.hpp"
 
-namespace cl {
-namespace sycl {
+namespace cl::sycl {
 
 /** \addtogroup data Data access and storage in SYCL
     @{
@@ -126,7 +125,6 @@ public:
 
 /// @} End the execution Doxygen group
 
-}
 }
 
 /*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -474,7 +474,7 @@ ctest:
 	# Think to delete this directory first if full recompilation is required...
 	mkdir -p ../build
 	cd ../build; cmake .. -DCMAKE_CXX_COMPILER=$(CXX) \
-	   -DTRISYCL_OPENCL=ON; make -j7; ctest -j7
+	   -DTRISYCL_OPENCL=ON; make -j`nproc`; ctest
 
 # Only display the test list
 ctest-list:


### PR DESCRIPTION
Use C++17 nested namespace

Mainly use
clang-tidy-9 --fix-errors --checks='-*,modernize-concat-nested-namespaces'
and fix a few errors manually.

Mention -DCMAKE_EXPORT_COMPILE_COMMANDS=1 for using some refactoring tools.

Compile using just as many threads as CPU cores
Previous raw `-j` was doing a thread spamming, typically acting as a
deny-of-service on the machine because of memory limitations.
Note that it might be still too high for small-memory systems...
