### PR TITLE
only build tests subdirectory if BUILD_TESTING is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ include_directories(${PROJECT_SOURCE_DIR}/tests/common) # All targets inherit SY
 
 
 # Recurse into tests dir to pick up unit tests
-add_subdirectory(tests)
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 add_library(${PROJECT_NAME} INTERFACE)
 


### PR DESCRIPTION
This is a super minor improvement: using CPack automatically creates the `BUILD_TESTING` option in CMake, which is `ON` by default. If this is explicitly turned off, there's no reason to compile all the tests, which can take quite a long time to compile. This lets users (like me) do a `make install` without the need to compile things I don't care about in certain situations.