### PR TITLE
Make the definition of alternate namespace more liberal

### DIFF
--- a/include/CL/sycl.hpp
+++ b/include/CL/sycl.hpp
@@ -9,10 +9,11 @@
 
 #include "triSYCL/sycl.hpp"
 
-namespace cl {
-  /// The official SYCL 1.2.1 specification exposes the API in the
-  /// ::cl::sycl namespace
-  namespace sycl = ::trisycl;
+/// The official SYCL 1.2.1 specification exposes the API in the
+/// ::cl::sycl namespace
+namespace cl::sycl {
+  // Make the triSYCL implementation appear here
+  using namespace ::trisycl;
 }
 
 /*

--- a/include/SYCL/sycl.hpp
+++ b/include/SYCL/sycl.hpp
@@ -11,7 +11,11 @@
 
 #include "triSYCL/sycl.hpp"
 
-namespace sycl = ::trisycl;
+/// Expose the SYCL API directly in the ::sycl namespace
+namespace sycl {
+  // Make the triSYCL implementation appear here
+  using namespace ::trisycl;
+}
 
 /*
     # Some Emacs stuff:


### PR DESCRIPTION
Declare ::cl and ::cl::sycl in a different way.
This should fix https://github.com/triSYCL/triSYCL/issues/256 in case
there is already an existing ::cl::sycl or ::sycl
This sounds like a better neighborhood behavior.