### PR TITLE
Use standard C++ attribute syntax

### DIFF
--- a/include/triSYCL/detail/instantiate_kernel.hpp
+++ b/include/triSYCL/detail/instantiate_kernel.hpp
@@ -22,14 +22,14 @@ namespace trisycl::detail {
 /** Avoid the interprocedural optimization to remove these arguments
     in the kernel instantiation by relying on some dummy static variables.
 
-    Using \c __attribute__((used)) does not work on arguments but only
+    Using \c [[gnu::used]] does not work on arguments but only
     on static variable, so use this function.
 */
 auto prevent_arguments_from_optimization = [] (auto & ...args) {
   /* Just keep track of the address of all the given objects,
      otherwise the objects are copied, may throw, are registered for
      destruction with \c atexit(), etc. */
-  static auto __attribute__((used)) keep = std::make_tuple(& args...);
+  [[gnu::used]] static auto keep = std::make_tuple(& args...);
 };
 
 
@@ -47,7 +47,7 @@ auto prevent_arguments_from_optimization = [] (auto & ...args) {
 */
 template <typename KernelName,
           typename Functor>
-__attribute__((noinline)) void
+[[gnu::noinline]] void
 instantiate_kernel(Functor f) noexcept {
   /* The outlining compiler is expected to do some massage here or
      around and to insert some calls to \c serialize_arg and so on */
@@ -87,7 +87,7 @@ set_kernel_task_marker(detail::task &) noexcept {
 */
 template <typename KernelName,
           typename Kernel>
-__attribute__((noinline))
+[[gnu::noinline]]
 void launch_device_kernel(detail::task &t,
                           Kernel k) noexcept {
   /** Setup the task to be used to launch the kernel.


### PR DESCRIPTION
Instead of using the GNU style `__attribute__` we should rely on the standard C++ attribute syntax. This makes things more portable since any C++17 conforming compiler will ignore unknown attributes, thus preventing issues as noted in #269. 

This PR should fix the issues mentioned in #269. In the long-term it might make sense to use clang's OpenCL attributes (`clang::opencl_global`) for address spaces but that would require a more extensive rework of the current address space implementation.