### PR TITLE
Implement SYCL extension for sycl::vec<> with structure binding

### DIFF
--- a/include/triSYCL/detail/alignment_helper.hpp
+++ b/include/triSYCL/detail/alignment_helper.hpp
@@ -13,6 +13,12 @@
     License. See LICENSE.TXT for details.
 */
 
+namespace trisycl {
+/// forward declaration to use in the detail class
+template<typename, int>
+class vec;
+}
+
 namespace trisycl::detail {
   template <typename T>
   class alignment {

--- a/include/triSYCL/rounding_mode.hpp
+++ b/include/triSYCL/rounding_mode.hpp
@@ -1,0 +1,33 @@
+#ifndef TRISYCL_SYCL_ROUNDING_MODE_HPP
+#define TRISYCL_SYCL_ROUNDING_MODE_HPP
+
+/** \file
+
+    Define rounding modes used in SYCL
+
+    This file is distributed under the University of Illinois Open Source
+    License. See LICENSE.TXT for details.
+*/
+
+namespace trisycl {
+
+/// Rounding mode for vector conversions
+enum class rounding_mode {
+  automatic, /// Default rounding mode, rtz for integers, rte for floating-point
+  rte,       /// Round to nearest even
+  rtz,       /// Round towards zero
+  rtp,       /// Round towards positive infinity
+  rtn        /// Round towards negative infinity
+};
+
+}
+
+/*
+    # Some Emacs stuff:
+    ### Local Variables:
+    ### ispell-local-dictionary: "american"
+    ### eval: (flyspell-prog-mode)
+    ### End:
+*/
+
+#endif // TRISYCL_SYCL_ROUNDING_MODE_HPP

--- a/include/triSYCL/vec.hpp
+++ b/include/triSYCL/vec.hpp
@@ -561,6 +561,45 @@ public:
 
 }
 
+
+namespace std {
+/* Provide a tuple-like interface to the SYCL vec with some type
+   traits and function template specialization in std::, besides the
+   get<> member function.
+
+   This is useful to have a data type compatible with structure binding
+*/
+
+/// The std::tuple_element specialization for vec
+template<std::size_t I, typename T, int Size>
+struct tuple_element<I, trisycl::vec<T, Size>> {
+  static_assert(I < Size, "The vec<> has not enough elements!");
+  // All the elements have the same type
+  using type = T;
+};
+
+
+/// The std::tuple_size specialization for vec
+template <typename T, int Size>
+class tuple_size<trisycl::vec<T, Size>>
+  : public integral_constant<size_t, Size>
+{ };
+
+
+/** Provide a get<> accessor to have C++17 structured binding working
+
+    Note that it works without this with current std::array based
+    implementation on the host device but we prefer to have a more
+    realistic const binding
+*/
+template <int I, typename T, int Size>
+auto get(const trisycl::vec<T, Size>& v) {
+  static_assert(I < Size, "The vec<> has not enough elements!");
+  return v[I];
+}
+
+}
+
 /*
     # Some Emacs stuff:
     ### Local Variables:

--- a/include/triSYCL/vec.hpp
+++ b/include/triSYCL/vec.hpp
@@ -3,7 +3,7 @@
 
 /** \file
 
-    Implement the small OpenCL vector class
+    Implement the small vector class
 
     Ronan at Keryell point FR
 
@@ -11,21 +11,19 @@
     License. See LICENSE.TXT for details.
 */
 
+#include <tuple>
+#include <utility>
+
+#include "triSYCL/rounding_mode.hpp"
+#include "triSYCL/detail/alignment_helper.hpp"
+#include "triSYCL/vec/detail/vec.hpp"
+
 namespace trisycl {
 
-/** Rounding mode for vector conversions.
- */
-enum class rounding_mode {
-  automatic, /// Default rounding mode, rtz for integers, rte for floating-point
-  rte,       /// Round to nearest even
-  rtz,       /// Round towards zero
-  rtp,       /// Round towards positive infinity
-  rtn        /// Round towards negative infinity
-};
-
 /** Series of values to specify named swizzle indexes
- *  Used when calling the swizzle member function template.
- */
+
+    Used when calling the swizzle member function template
+*/
 struct elem {
   static constexpr int x = 0;
   static constexpr int y = 1;
@@ -53,32 +51,19 @@ struct elem {
   static constexpr int sF = 15;
 };
 
-/** forward decl to use in the detail class
- */
-template<typename, int>
-class vec;
-
 template <typename DataType, int numElements>
 using __swizzled_vec__ = vec<DataType, numElements>;
 
 }
-
 
 /** \addtogroup vector Vector types in SYCL
 
     @{
 */
 
-
-/** Small OpenCL vector class
-*/
-
-#include "triSYCL/detail/alignment_helper.hpp"
-#include "triSYCL/vec/detail/vec.hpp"
-
+/// Small SYCL vector class
 namespace trisycl {
-  /** Accessors to access hex indexed elements of a vector
-   */
+  /// Accessors to access hex indexed elements of a vector
 #define TRISYCL_DECLARE_S(x)                          \
   const DataType& s##x() const {                      \
     return (*this)[0x##x];                            \

--- a/include/triSYCL/vec.hpp
+++ b/include/triSYCL/vec.hpp
@@ -581,8 +581,8 @@ struct tuple_element<I, trisycl::vec<T, Size>> {
 
 /// The std::tuple_size specialization for vec
 template <typename T, int Size>
-class tuple_size<trisycl::vec<T, Size>>
-  : public integral_constant<size_t, Size>
+struct tuple_size<trisycl::vec<T, Size>>
+  : integral_constant<size_t, Size>
 { };
 
 

--- a/include/triSYCL/vec/detail/vec.hpp
+++ b/include/triSYCL/vec/detail/vec.hpp
@@ -2,11 +2,12 @@
 #define TRISYCL_SYCL_VEC_DETAIL_VEC_HPP
 
 #include <cstring>
+#include <tuple>
 #include <utility>
 
 /** \file
 
-    Implement the detail base OpenCL vector class
+    Implement the detail base SYCL vector class
 
     Ronan at Keryell point FR
     Dave Airlie
@@ -15,18 +16,27 @@
     License. See LICENSE.TXT for details.
 */
 
+#include "triSYCL/rounding_mode.hpp"
 #include "triSYCL/detail/alignment_helper.hpp"
 #include "triSYCL/detail/array_tuple_helpers.hpp"
 
+namespace trisycl {
+
+template <typename DataType, int numElements>
+using __swizzled_vec__ = vec<DataType, numElements>;
+
+}
+
 namespace trisycl::detail {
 
+/// forward declaration to use in the detail class
 template <typename, int>
 class vec;
-template <typename DataType, int numElements>
-using __swizzled_base_vec__ = detail::vec<DataType, numElements>;
 
-/** Small OpenCL vector class
- */
+template <typename DataType, int numElements>
+using __swizzled_base_vec__ = vec<DataType, numElements>;
+
+/// Small SYCL vector class
 template <typename DataType, int NumElements>
 class alignas(alignment_v<::trisycl::vec<DataType, NumElements>>)
   vec : public detail::small_array<DataType,
@@ -48,7 +58,7 @@ public:
     : basic_type { detail::expand<vec>(flatten_to_tuple<vec>(args...)) } { }
 
 
-/// Use classical constructors too
+  /// Use classical constructors too
   vec() = default;
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -157,10 +157,10 @@ CLEANING_TARGETS += $(KERNELS_BC) $(KERNELS_BIN) $(KERNELS_INTERNALIZED_CXX) \
 	$(KERNELS_CALLER_BC) $(KERNELS_CALLER) $(KERNELS_XPIRBC) $(KERNELS_XO) \
 	$(KERNELS_BIN_INFO)
 
-# The implementation uses C++14.
+# The implementation uses C++17.
 # Use -Wno-ignored-attributes to avoid a lot of warning with
 # Boost.Compute and g++ version >= 6
-CXXFLAGS += -Wall -Wno-ignored-attributes -std=c++1z -I$(triSYCL_DIR)/include \
+CXXFLAGS += -Wall -Wno-ignored-attributes -std=c++17 -I$(triSYCL_DIR)/include \
 	-I$(triSYCL_DIR)/tests/common
 
 # Vivado HLS path
@@ -255,9 +255,9 @@ check:  $(TARGETS_CC)
 	# Launch testing with lit tool from LLVM in current directory
 	echo Using $(CXX) compiler:
 	# lit can be found for example on Debian/Ubuntu in package
-	# llvm-9-tools in /usr/lib/llvm-9/build/utils/lit/lit.py
+	# llvm-10-tools in /usr/lib/llvm-10/build/utils/lit/lit.py
 	# so try before running the check:
-	# export TRISYCL_LIT=/usr/lib/llvm-9/build/utils/lit/lit.py
+	# export TRISYCL_LIT=/usr/lib/llvm-10/build/utils/lit/lit.py
 	# The config file for triSYCL needs at least Python 3.3
 	test "unset$$TRISYCL_LIT == unset" \
 	  && echo 'Initialize TRISYCL_LIT variable to the path of "lit" command' ; \

--- a/tests/vector/CMakeLists.txt
+++ b/tests/vector/CMakeLists.txt
@@ -3,6 +3,7 @@ project (vector) # The name of our project
 
 declare_trisycl_test(TARGET operators)
 declare_trisycl_test(TARGET vec)
+declare_trisycl_test(TARGET vec_structured_binding)
 declare_trisycl_test(TARGET vecalign)
 declare_trisycl_test(TARGET vecas)
 declare_trisycl_test(TARGET vecconvert)

--- a/tests/vector/vec_structured_binding.cpp
+++ b/tests/vector/vec_structured_binding.cpp
@@ -1,0 +1,37 @@
+/* RUN: %{execute}%s
+
+   Test some vec<> behaviour about structured binding
+*/
+#include <CL/sycl.hpp>
+#include <boost/test/minimal.hpp>
+
+int test_main(int argc, char *argv[]) {
+  {
+    cl::sycl::vec<int, 1> v1i = { 12 };
+    const auto [ x ] = v1i;
+    // Note that it is just a naming coincidence to have x in both lhs and rhs
+    BOOST_CHECK(x == v1i.x());
+  }
+  {
+    cl::sycl::vec<int, 2> v2i = { 1, 2 };
+    const auto [ x, y ] = v2i;
+    BOOST_CHECK(x == v2i.x());
+    BOOST_CHECK(y == v2i.y());
+  }
+  {
+    cl::sycl::vec<int, 3> v3i = { 1, 2, 3 };
+    const auto [ x, y, z ] = v3i;
+    BOOST_CHECK(x == v3i.x());
+    BOOST_CHECK(y == v3i.y());
+    BOOST_CHECK(z == v3i.z());
+  }
+  {
+    cl::sycl::vec<int, 4> v4i = { 1, 2, 3, 4 };
+    const auto [ r, g, b, a ] = v4i;
+    BOOST_CHECK(r == v4i.r());
+    BOOST_CHECK(g == v4i.g());
+    BOOST_CHECK(b == v4i.b());
+    BOOST_CHECK(a == v4i.a());
+  }
+  return 0;
+}


### PR DESCRIPTION
This should close the extension request https://github.com/triSYCL/triSYCL/issues/271