### PR TITLE
CMake improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,18 @@
-cmake_minimum_required (VERSION 3.5) # The minimum version of CMake necessary to build this project
+# The minimum version of CMake necessary to build this project
+cmake_minimum_required (VERSION 3.5)
 
 set(TRISYCL_VERSION_MAJOR 0)
 set(TRISYCL_VERSION_MINOR 1)
 set(TRISYCL_VERSION_PATCH 0)
-set(TRISYCL_VERSION "${TRISYCL_VERSION_MAJOR}.${TRISYCL_VERSION_MINOR}.${TRISYCL_VERSION_PATCH}")
+set(TRISYCL_VERSION
+  "${TRISYCL_VERSION_MAJOR}.${TRISYCL_VERSION_MINOR}.${TRISYCL_VERSION_PATCH}")
 
 project(triSYCL VERSION ${TRISYCL_VERSION} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-include(FindTriSYCL)
+include(FindtriSYCL)
 
 # Enable CTest
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ set(TRISYCL_VERSION_MAJOR 0)
 set(TRISYCL_VERSION_MINOR 1)
 set(TRISYCL_VERSION_PATCH 0)
 set(TRISYCL_VERSION "${TRISYCL_VERSION_MAJOR}.${TRISYCL_VERSION_MINOR}.${TRISYCL_VERSION_PATCH}")
+
 project(triSYCL VERSION ${TRISYCL_VERSION} LANGUAGES CXX)
-
-
 set(CMAKE_CXX_STANDARD 17)
+
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(FindTriSYCL)
@@ -16,9 +16,10 @@ include(FindTriSYCL)
 include(CTest)
 enable_testing()
 
-include_directories(${PROJECT_SOURCE_DIR}/include) # All targets inherit SYCL include dir
-include_directories(${PROJECT_SOURCE_DIR}/tests/common) # All targets inherit SYCL include dir
-
+ # All targets inherit SYCL include dir
+include_directories(${PROJECT_SOURCE_DIR}/include)
+ # All targets inherit SYCL test include dir since it is about testing here
+include_directories(${PROJECT_SOURCE_DIR}/tests/common)
 
 # Recurse into tests dir to pick up unit tests
 if (BUILD_TESTING)

--- a/cmake/FindTriSYCL.cmake
+++ b/cmake/FindTriSYCL.cmake
@@ -14,7 +14,8 @@
 # Requite CMake version 3.5 or higher
 
 cmake_minimum_required (VERSION 3.5)
-project(triSYCL CXX) # The name of the project (forward declare language)
+# The name of the project (forward declare language)
+project(triSYCL CXX)
 
 #######################
 #  set_target_cxx_std
@@ -189,7 +190,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
 if(NOT TRISYCL_INCLUDE_DIR)
-  set(TRISYCL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+  # Set the location from the local directory instead of the project
+  # directory, so the location is correct even when this file is
+  # included from anywhere
+  set(TRISYCL_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/../include)
 endif()
 
 if(EXISTS ${TRISYCL_INCLUDE_DIR})

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -278,7 +278,9 @@ function(add_sycl_to_target targetName)
     Boost::fiber
     Boost::thread
     #Required by BOOST_COMPUTE_USE_OFFLINE_CACHE:
-    $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem>)
+    $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem>
+    range-v3::range-v3
+  )
 
   # Compile definitions
   target_compile_definitions(${targetName} PUBLIC

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -1,12 +1,12 @@
 #.rst:
-# FindTriSYCL
+# FindtriSYCL
 #---------------
 #
 # This file is distributed under the University of Illinois Open Source
 # License. See LICENSE.TXT for details.
 
 #########################
-#  FindTriSYCL.cmake
+#  FindtriSYCL.cmake
 #########################
 #
 # Tools for finding and building with triSYCL.

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -249,6 +249,8 @@ message(STATUS "triSYCL kernel trace:             ${TRISYCL_TRACE_KERNEL}")
 
 find_package(Threads REQUIRED)
 
+find_package(range-v3 REQUIRED)
+
 #######################
 #  add_sycl_to_target
 #######################

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -223,8 +223,8 @@ if(TRISYCL_TBB)
   find_package(TBB REQUIRED)
 endif()
 
-# Find Boost
-set(BOOST_REQUIRED_COMPONENTS chrono fiber log thread)
+# Find specifically the non pure header Boost library packages
+set(BOOST_REQUIRED_COMPONENTS context fiber log thread)
 
 if(TRISYCL_OPENCL)
   list(APPEND BOOST_REQUIRED_COMPONENTS filesystem)
@@ -272,6 +272,7 @@ function(add_sycl_to_target targetName)
     Threads::Threads
     $<$<BOOL:${LOG_NEEDED}>:Boost::log>
     Boost::chrono
+    Boost::context
     Boost::fiber
     Boost::thread
     $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem> #Required by BOOST_COMPUTE_USE_OFFLINE_CACHE.

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -275,8 +275,8 @@ function(add_sycl_to_target targetName)
     Boost::context
     Boost::fiber
     Boost::thread
-    $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem> #Required by BOOST_COMPUTE_USE_OFFLINE_CACHE.
-    ${GTKMM_LIBRARIES})
+    #Required by BOOST_COMPUTE_USE_OFFLINE_CACHE:
+    $<$<BOOL:${TRISYCL_OPENCL}>:Boost::filesystem>)
 
   # Compile definitions
   target_compile_definitions(${targetName} PUBLIC

--- a/doc/cmake.rst
+++ b/doc/cmake.rst
@@ -38,7 +38,7 @@ To compile the tests with OpenCL, use for example on Unix::
   cmake .. -DTRISYCL_OPENCL=ON
   # Use as many compilation threads as we have CPU cores
   # but it might be dangerous if there is not enough memory per core
-  make -j`nproc`
+  cmake --build . --parallel `nproc`
 
 Adding the option ``-DCMAKE_EXPORT_COMPILE_COMMANDS=1`` to the CMake
 parameter is useful to generate the compilation database used by some
@@ -69,6 +69,17 @@ LIT, can test exit codes and match stdout vs. a regex.
 To run the tests once compiled, use for example::
 
   ctest
+
+
+Building a package with CPack
+-----------------------------
+
+Look at the `CPack <https://cmake.org/cmake/help/latest/module/CPack.html>`_ documentation online.
+
+For example on a Debian/Ubuntu system, a `.deb` package can be
+generated with::
+
+  cmake --build . --target package
 
 
 Warning-free

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -18,7 +18,7 @@ latest Ubuntu too, just adapt the compiler versions):
 
 .. code:: bash
 
-  sudo apt-get install clang-9 g++-9 libboost-dev
+  sudo apt-get install clang-10 g++-10 libomp-dev libboost-all-dev librange-v3-dev
 
 There is nothing else to do for now to use the include files from triSYCL_
 ``include`` directory when compiling a program. Just add a


### PR DESCRIPTION
Modernize the CMake configuration so it can be used remotely for testing.
See https://github.com/keryell/muSYCL for an example.

This is a WIP since there are some lacking libraries in the CMake configuration, according to https://github.com/triSYCL/triSYCL/issues/285, https://github.com/triSYCL/triSYCL/issues/283, https://github.com/triSYCL/triSYCL/issues/284.