### PR TITLE
 Generalize mathematical functions on sycl::vec

### DIFF
--- a/include/triSYCL/vec/detail/vec.hpp
+++ b/include/triSYCL/vec/detail/vec.hpp
@@ -157,15 +157,6 @@ private:
         std::make_index_sequence<std::tuple_size<decltype(xTuple)>::value>());
   }
 
-
-  template<typename T, typename T2, typename F>
-  static auto apply_ternary_functor(const T x, const T2 y, const T2 z, F f) {
-    auto xTuple = flatten_to_tuple<T>(x);
-    auto yTuple = flatten_to_tuple<T>(y);
-    return apply_binary_functor_impl(xTuple, yTuple, f,
-        std::make_index_sequence<std::tuple_size<decltype(xTuple)>::value>());
-  }
-
 protected:
 
   /// Apply a swizzle operation from swizzleIndexes parameters

--- a/tests/math/vector_math.cpp
+++ b/tests/math/vector_math.cpp
@@ -7,19 +7,16 @@
 #include <cmath>
 #include <iostream>
 #include <numeric>
-#include <type_traits>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <boost/test/minimal.hpp>
 
-using namespace cl::sycl;
-
 template <typename T, int Dim>
-void do_vec_unary_math(vec<T, Dim> v) {
-  auto floor = cl::sycl::floor(v);
-  auto clamp = cl::sycl::clamp(v, 2.0f, 4.0f);
-  auto length = cl::sycl::length(v);
-  auto normalize = cl::sycl::normalize(v);
+void do_vec_unary_math(sycl::vec<T, Dim> v) {
+  auto clamp = sycl::clamp(v, 2.0f, 4.0f);
+  auto floor = sycl::floor(v);
+  auto length = sycl::length(v);
+  auto normalize = sycl::normalize(v);
 
   T len {0};
   for (int i = 0; i < Dim; ++i) {
@@ -31,20 +28,20 @@ void do_vec_unary_math(vec<T, Dim> v) {
   BOOST_CHECK(length == len);
 
   for (int i = 0; i < Dim; ++i) {
-    BOOST_CHECK(normalize[i] == v[i] / len);
-    BOOST_CHECK(floor[i] == std::floor(v[i]));
     BOOST_CHECK(clamp[i] == std::clamp(v[i], 2.0f, 4.0f));
+    BOOST_CHECK(floor[i] == std::floor(v[i]));
+    BOOST_CHECK(normalize[i] == v[i] / len);
   }
 }
 
 // only intended for vecs of equal size, similar to the implemented math
 // functions
 template <typename T, int Dim>
-void do_vec_binary_math(vec<T, Dim> v, vec<T, Dim> v2) {
-  auto fmin = cl::sycl::fmin(v, v2);
-  auto fmax = cl::sycl::fmax(v, v2);
-  auto min = cl::sycl::min(v, v2);
-  auto max = cl::sycl::max(v, v2);
+void do_vec_binary_math(sycl::vec<T, Dim> v, sycl::vec<T, Dim> v2) {
+  auto fmin = sycl::fmin(v, v2);
+  auto fmax = sycl::fmax(v, v2);
+  auto min = sycl::min(v, v2);
+  auto max = sycl::max(v, v2);
 
   for (int i = 0; i < Dim; ++i) {
     BOOST_CHECK(fmin[i] == std::fmin(v2[i], v[i]));
@@ -55,16 +52,15 @@ void do_vec_binary_math(vec<T, Dim> v, vec<T, Dim> v2) {
 }
 
 int test_main(int argc, char *argv[]) {
-  float2 f2 {2.3f, 4.1f};
-  float3 f3_a {1,2,3};
-  float3 f3_b {1,5,7};
-  float3 f3_c {3.0,1.0,2.0};
-  float4 f4_a {1,2,3,2};
-  float4 f4_b {1,5,7,4};
-  float8 f8 {-5.0f,-5.1f,-5.9f,-6.9f,-6.1f,5.0f,5.1f,5.9f};
-  float16 f16_a {10.0f,10.0f,10.0f,10.0f,10.0f,10.0f,10.0f,10.0f,10.0f,10.0f,
-                 10.0f,10.0f,10.0f,10.0f,10.0f,10.0f};
-  float16 f16_b {15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15};
+  sycl::float2 f2 {2.3f, 4.1f};
+  sycl::float3 f3_a {1,2,3};
+  sycl::float3 f3_b {1,5,7};
+  sycl::float3 f3_c {3.0,1.0,2.0};
+  sycl::float4 f4_a {1,2,3,2};
+  sycl::float4 f4_b {1,5,7,4};
+  sycl::float8 f8 {-5.0f,-5.1f,-5.9f,-6.9f,-6.1f,5.0f,5.1f,5.9f};
+  sycl::float16 f16_a {10.0f};
+  sycl::float16 f16_b {15};
 
   do_vec_unary_math(f2);
   do_vec_unary_math(f3_a);
@@ -82,8 +78,8 @@ int test_main(int argc, char *argv[]) {
   // do_vec_binary_math(f16_a, f16_b);
 
   // not as trivially testable generically as the above
-  auto cross3_ab = cl::sycl::cross(f3_a, f3_b);
-  auto cross4_ab = cl::sycl::cross(f4_a, f4_b);
+  auto cross3_ab = sycl::cross(f3_a, f3_b);
+  auto cross4_ab = sycl::cross(f4_a, f4_b);
 
   BOOST_CHECK(cross3_ab.x() == -1);
   BOOST_CHECK(cross3_ab.y() == -4);
@@ -94,9 +90,9 @@ int test_main(int argc, char *argv[]) {
   BOOST_CHECK(cross4_ab.z() == 3);
   BOOST_CHECK(cross4_ab.w() == 0);
 
-  auto dot3_ab = cl::sycl::dot(f3_a, f3_b);
-  auto dot4_ab = cl::sycl::dot(f4_a, f4_b);;
-  auto dot16_ab = cl::sycl::dot(f16_a, f16_b);;
+  auto dot3_ab = sycl::dot(f3_a, f3_b);
+  auto dot4_ab = sycl::dot(f4_a, f4_b);;
+  auto dot16_ab = sycl::dot(f16_a, f16_b);;
 
   BOOST_CHECK(dot3_ab == 32);
   BOOST_CHECK(dot4_ab == 40);

--- a/tests/math/vector_math.cpp
+++ b/tests/math/vector_math.cpp
@@ -13,6 +13,7 @@
 
 template <typename T, int Dim>
 void do_vec_unary_math(sycl::vec<T, Dim> v) {
+  auto abs = sycl::abs(v);
   auto clamp = sycl::clamp(v, 2.0f, 4.0f);
   auto floor = sycl::floor(v);
   auto length = sycl::length(v);
@@ -28,6 +29,7 @@ void do_vec_unary_math(sycl::vec<T, Dim> v) {
   BOOST_CHECK(length == len);
 
   for (int i = 0; i < Dim; ++i) {
+    BOOST_CHECK(abs[i] == std::abs(v[i]));
     BOOST_CHECK(clamp[i] == std::clamp(v[i], 2.0f, 4.0f));
     BOOST_CHECK(floor[i] == std::floor(v[i]));
     BOOST_CHECK(normalize[i] == v[i] / len);


### PR DESCRIPTION
Test that sycl::abs now works for sycl::vec.
This should be tested quite more...
This is adds a little bit to https://github.com/triSYCL/triSYCL/issues/40