### PR TITLE
Improve debug tracing class

### DIFF
--- a/include/triSYCL/detail/debug.hpp
+++ b/include/triSYCL/detail/debug.hpp
@@ -163,7 +163,7 @@ struct display_vector {
     std::cout << boost::typeindex::type_id<T>().pretty_name() << ":";
 #endif
     // Get a pointer to the real object
-    for (auto e : *static_cast<const T *>(this))
+    for (auto e : static_cast<const T&>(*this))
       std::cout << " " << e;
     std::cout << std::endl;
   }

--- a/include/triSYCL/detail/debug.hpp
+++ b/include/triSYCL/detail/debug.hpp
@@ -67,27 +67,29 @@ namespace trisycl::detail {
 template <typename T>
 struct debug {
 #ifdef TRISYCL_DEBUG_STRUCTORS
+  /// Get the name of T itself
+  static auto constexpr pn() {
+    return boost::typeindex::type_id<T>().pretty_name();
+  }
+
+
   /// Trace the construction with the compiler-dependent mangled named
   debug() {
-    TRISYCL_DUMP("Constructor of "
-                 << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << static_cast<void*>(this));
+    TRISYCL_DUMP("Constructor of " << pn() << " " << static_cast<void*>(this));
   }
 
 
   /** Trace the copy construction with the compiler-dependent mangled
       named */
   debug(debug const& old) {
-    TRISYCL_DUMP("Copy of " << boost::typeindex::type_id<T>().pretty_name()
-                 << " into " << static_cast<void*>(this)
+    TRISYCL_DUMP("Copy of " << pn() << " into " << static_cast<void*>(this)
                  << " from " << static_cast<const void*>(&old));
   }
 
 
   /// Trace the copy assignment
   debug& operator=(const debug& rhs) {
-    TRISYCL_DUMP("Copy assignment of "
-                 << boost::typeindex::type_id<T>().pretty_name()
+    TRISYCL_DUMP("Copy assignment of " << pn()
                  << " into " << static_cast<void*>(this)
                  << " from " << static_cast<const void*>(&rhs));
     return *this;
@@ -97,16 +99,14 @@ struct debug {
   /** Trace the move construction with the compiler-dependent mangled
       named */
   debug(debug&& old) {
-    TRISYCL_DUMP("Move of " << boost::typeindex::type_id<T>().pretty_name()
-                 << " into " << static_cast<void*>(this)
+    TRISYCL_DUMP("Move of " << pn() << " into " << static_cast<void*>(this)
                  << " from " << static_cast<void*>(&old));
   }
 
 
   /// Trace the move assignment
   debug& operator=(debug&& rhs) {
-    TRISYCL_DUMP("Move assignment of "
-                 << boost::typeindex::type_id<T>().pretty_name()
+    TRISYCL_DUMP("Move assignment of " << pn()
                  << " into " << static_cast<void*>(this)
                  << " from " << static_cast<void*>(&rhs));
     return *this;
@@ -115,9 +115,7 @@ struct debug {
 
   /// Trace the destruction with the compiler-dependent mangled named
   ~debug() {
-    TRISYCL_DUMP("~ Destructor of "
-                 << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << static_cast<void*>(this));
+    TRISYCL_DUMP("~ Destructor of " << pn() << " " << static_cast<void*>(this));
   }
 #endif
 };

--- a/include/triSYCL/detail/debug.hpp
+++ b/include/triSYCL/detail/debug.hpp
@@ -15,14 +15,15 @@
 
 #include <iostream>
 
-// The common debug and trace infrastructure
+#include <boost/type_index.hpp>
+
+// Only when the common debug or trace infrastructure is required
 #if defined(TRISYCL_DEBUG) || defined(TRISYCL_TRACE_KERNEL)
 #include <sstream>
 #include <string>
 #include <thread>
 
 #include <boost/log/trivial.hpp>
-#include <boost/type_index.hpp>
 
 // To be able to construct string literals like "blah"s
 using namespace std::string_literals;
@@ -60,62 +61,64 @@ namespace trisycl::detail {
 /** Class used to trace the construction, copy-construction,
     move-construction and destruction of classes that inherit from it
 
-    Also trace the assignments.
+    Also trace the copy and move assignments.
 
     \param T is the real type name to be used in the debug output.
 */
 template <typename T>
 struct debug {
-#ifdef TRISYCL_DEBUG_STRUCTORS
-  /// Get the name of T itself
-  static auto constexpr pn() {
+  /// Get the pretty name of T itself
+  static auto constexpr type_pretty_name() {
     return boost::typeindex::type_id<T>().pretty_name();
   }
 
+#ifdef TRISYCL_DEBUG_STRUCTORS
 
-  /// Trace the construction with the compiler-dependent mangled named
+  /// Trace the construction
   debug() {
-    TRISYCL_DUMP("Constructor of " << pn() << " " << static_cast<void*>(this));
+    TRISYCL_DUMP("Constructor of " << type_pretty_name() << " "
+                 << static_cast<void*>(this));
   }
 
 
-  /** Trace the copy construction with the compiler-dependent mangled
-      named */
+  /// Trace the copy construction
   debug(debug const& old) {
-    TRISYCL_DUMP("Copy of " << pn() << " into " << static_cast<void*>(this)
-                 << " from " << static_cast<const void*>(&old));
+    TRISYCL_DUMP("Copy of " << type_pretty_name() << " into "
+                 << static_cast<void*>(this) << " from "
+                 << static_cast<const void*>(&old));
   }
 
 
   /// Trace the copy assignment
   debug& operator=(const debug& rhs) {
-    TRISYCL_DUMP("Copy assignment of " << pn()
+    TRISYCL_DUMP("Copy assignment of " << type_pretty_name()
                  << " into " << static_cast<void*>(this)
                  << " from " << static_cast<const void*>(&rhs));
     return *this;
   }
 
 
-  /** Trace the move construction with the compiler-dependent mangled
-      named */
+  /// Trace the move construction
   debug(debug&& old) {
-    TRISYCL_DUMP("Move of " << pn() << " into " << static_cast<void*>(this)
-                 << " from " << static_cast<void*>(&old));
+    TRISYCL_DUMP("Move of " << type_pretty_name() << " into "
+                 << static_cast<void*>(this) << " from "
+                 << static_cast<void*>(&old));
   }
 
 
   /// Trace the move assignment
   debug& operator=(debug&& rhs) {
-    TRISYCL_DUMP("Move assignment of " << pn()
+    TRISYCL_DUMP("Move assignment of " << type_pretty_name()
                  << " into " << static_cast<void*>(this)
                  << " from " << static_cast<void*>(&rhs));
     return *this;
   }
 
 
-  /// Trace the destruction with the compiler-dependent mangled named
+  /// Trace the destruction
   ~debug() {
-    TRISYCL_DUMP("~ Destructor of " << pn() << " " << static_cast<void*>(this));
+    TRISYCL_DUMP("~ Destructor of " << type_pretty_name() << " "
+                 << static_cast<void*>(this));
   }
 #endif
 };

--- a/include/triSYCL/detail/debug.hpp
+++ b/include/triSYCL/detail/debug.hpp
@@ -60,55 +60,56 @@ namespace trisycl::detail {
 /** Class used to trace the construction, copy-construction,
     move-construction and destruction of classes that inherit from it
 
+    Also trace the assignments.
+
     \param T is the real type name to be used in the debug output.
 */
 template <typename T>
 struct debug {
-  // To trace the execution of the conSTRUCTORs and deSTRUCTORs
 #ifdef TRISYCL_DEBUG_STRUCTORS
   /// Trace the construction with the compiler-dependent mangled named
   debug() {
     TRISYCL_DUMP("Constructor of "
                  << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << (void*) this);
+                 << " " << static_cast<void*>(this));
   }
 
 
   /** Trace the copy construction with the compiler-dependent mangled
-      named
-
-      Only add this constructor if T has itself the same constructor,
-      otherwise it may prevent the synthesis of default copy
-      constructor and assignment.
-  */
-  template <typename U = T>
-  debug(debug const &,
-        /* Use intermediate U type to have the type dependent for
-           enable_if to work
-
-        \todo Use is_copy_constructible_v when moving to C++17 */
-        std::enable_if_t<std::is_copy_constructible<U>::value> * = 0) {
+      named */
+  debug(debug const& old) {
     TRISYCL_DUMP("Copy of " << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << (void*) this);
+                 << " into " << static_cast<void*>(this)
+                 << " from " << static_cast<const void*>(&old));
+  }
+
+
+  /// Trace the copy assignment
+  debug& operator=(const debug& rhs) {
+    TRISYCL_DUMP("Copy assignment of "
+                 << boost::typeindex::type_id<T>().pretty_name()
+                 << " into " << static_cast<void*>(this)
+                 << " from " << static_cast<const void*>(&rhs));
+    return *this;
   }
 
 
   /** Trace the move construction with the compiler-dependent mangled
-      named
-
-      Only add this constructor if T has itself the same constructor,
-      otherwise it may prevent the synthesis of default move
-      constructor and move assignment.
-  */
-  template <typename U = T>
-  debug(debug &&,
-        /* Use intermediate U type to have the type dependent for
-           enable_if to work
-
-        \todo Use is_move_constructible_v when moving to C++17 */
-        std::enable_if_t<std::is_move_constructible<U>::value> * = 0) {
+      named */
+  debug(debug&& old) {
     TRISYCL_DUMP("Move of " << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << (void*) this);
+                 << " into " << static_cast<void*>(this)
+                 << " from " << static_cast<void*>(&old));
+  }
+
+
+  /// Trace the move assignment
+  debug& operator=(debug&& rhs) {
+    TRISYCL_DUMP("Move assignment of "
+                 << boost::typeindex::type_id<T>().pretty_name()
+                 << " into " << static_cast<void*>(this)
+                 << " from " << static_cast<void*>(&rhs));
+    return *this;
   }
 
 
@@ -116,7 +117,7 @@ struct debug {
   ~debug() {
     TRISYCL_DUMP("~ Destructor of "
                  << boost::typeindex::type_id<T>().pretty_name()
-                 << " " << (void*) this);
+                 << " " << static_cast<void*>(this));
   }
 #endif
 };

--- a/include/triSYCL/detail/small_array.hpp
+++ b/include/triSYCL/detail/small_array.hpp
@@ -295,8 +295,8 @@ struct small_array : std::array<BasicType, Dims>,
 
   /** Since the boost::operator work on the small_array, add an implicit
       conversion to produce the expected type */
-  operator FinalType () {
-    return *static_cast<FinalType *>(this);
+  operator FinalType() {
+    return static_cast<FinalType&>(*this);
   }
 };
 

--- a/include/triSYCL/kernel/detail/opencl_kernel.hpp
+++ b/include/triSYCL/kernel/detail/opencl_kernel.hpp
@@ -114,7 +114,7 @@ class opencl_kernel : public detail::kernel,
       (k,                                                               \
        static_cast<size_t>(N),                                          \
        NULL,                                                            \
-       static_cast<const size_t*>(num_work_items.data()) ,              \
+       static_cast<const size_t*>(num_work_items.data()),               \
        NULL);                                                           \
     /* For now use a crude synchronization mechanism to map directly a  \
        host task to an accelerator task */                              \

--- a/include/triSYCL/kernel/detail/opencl_kernel.hpp
+++ b/include/triSYCL/kernel/detail/opencl_kernel.hpp
@@ -114,7 +114,7 @@ class opencl_kernel : public detail::kernel,
       (k,                                                               \
        static_cast<size_t>(N),                                          \
        NULL,                                                            \
-       static_cast<const size_t *>(num_work_items.data()),              \
+       static_cast<const size_t*>(num_work_items.data()) ,              \
        NULL);                                                           \
     /* For now use a crude synchronization mechanism to map directly a  \
        host task to an accelerator task */                              \


### PR DESCRIPTION
The trisycl::detail::debug CRTP was using introspection of the native
type to know whether the type was copy and move constructible before
defining such a constructor to avoid preventing the generation of the
default assignment operator.
But actually this is an unsolvable question because of the
self-reference essence of the CRTP.
It was still working with G++ but no longer working starting with
Clang++-11.
So, instead, do not use std::enable_if or concepts but just define all
the operators.
A nice side effect is that now copy and move assignments can be traced
too.