### PR TITLE
[WIP] Implement a device facade to build generic conceptual SYCL devices

### DIFF
--- a/include/triSYCL/device.hpp
+++ b/include/triSYCL/device.hpp
@@ -10,6 +10,7 @@
 */
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <any>
 
@@ -19,7 +20,7 @@
 
 #include "triSYCL/detail/default_classes.hpp"
 
-#include "triSYCL/detail/shared_ptr_implementation.hpp"
+#include "triSYCL/device/facade/device.hpp"
 #include "triSYCL/device/detail/host_device.hpp"
 #ifdef TRISYCL_OPENCL
 #include "triSYCL/device/detail/opencl_device.hpp"
@@ -43,11 +44,10 @@ class platform;
 class device
   /* Use the underlying device implementation that can be shared in the
      SYCL model */
-  : public detail::shared_ptr_implementation<device, detail::device> {
+  : public facade::device<device, detail::device> {
 
   // The type encapsulating the implementation
-  using implementation_t =
-    detail::shared_ptr_implementation<device, detail::device>;
+  using implementation_t = facade::device<device, detail::device>;
 
 public:
 

--- a/include/triSYCL/device/facade/device.hpp
+++ b/include/triSYCL/device/facade/device.hpp
@@ -1,0 +1,44 @@
+#ifndef TRISYCL_SYCL_DEVICE_DETAIL_DEVICE_FACADE_DEVICE_HPP
+#define TRISYCL_SYCL_DEVICE_DETAIL_DEVICE_FACADE_DEVICE_HPP
+
+/** \file A SYCL device facade to implement more easily a SYCL
+    device concept
+
+    This file is distributed under the University of Illinois Open Source
+    License. See LICENSE.TXT for details.
+*/
+
+#include "triSYCL/detail/shared_ptr_implementation.hpp"
+
+namespace trisycl::facade {
+
+/** \addtogroup execution Platforms, contexts, devices and queues
+    @{
+*/
+
+/// SYCL device
+template <typename UserFacing, typename ImplementationDetail>
+class device
+  /* Use the underlying device implementation that can be shared in the
+     SYCL model */
+  : public detail::shared_ptr_implementation<UserFacing, ImplementationDetail> {
+
+public:
+
+  /// The type encapsulating the implementation
+  using implementation_t =
+    detail::shared_ptr_implementation<UserFacing, ImplementationDetail>;
+
+  /// The real detail type doing the work behind the scene
+  using detail_t = ImplementationDetail;
+
+  /// Import the constructors
+  using implementation_t::implementation_t;
+
+};
+
+/// @} to end the Doxygen group
+
+}
+
+#endif // TRISYCL_SYCL_DEVICE_DETAIL_DEVICE_FACADE_DEVICE_HPP


### PR DESCRIPTION
Useful to generalize SYCL devices with more or different API while
keeping the same conceptual behavior.
For example for devices like Xilinx AIE CGRA.