### PR TITLE
Fetch the content of the range-v3 library directly from the source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
   set(CPACK_PACKAGE_VERSION_MINOR ${TRISYCL_VERSION_MINOR} )
   set(CPACK_PACKAGE_VERSION_PATCH ${TRISYCL_VERSION_PATCH} )
 
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-dev,librange-v3-dev")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-dev")
   set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "opencl-c-headers (>=1.2), build-essential, cmake")
 
   include(CPack)

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -249,16 +249,17 @@ message(STATUS "triSYCL kernel trace:             ${TRISYCL_TRACE_KERNEL}")
 
 find_package(Threads REQUIRED)
 
-# Install the experimental mdspan implementation described in ISO C++
-# P0009 proposal
-# https://github.com/ORNL/cpp-proposals-pub/tree/master/P0009
+# To get some content directly at the source
 include(FetchContent)
 # Display what is happening behind the scene for less confusion
 set(FETCHCONTENT_QUIET FALSE)
+
+# Install the experimental mdspan implementation described in ISO C++
+# P0009 proposal https://github.com/ORNL/cpp-proposals-pub/tree/master/P0009
 FetchContent_Declare(experimental_mdspan
   GIT_REPOSITORY    https://github.com/kokkos/mdspan
   GIT_SHALLOW       TRUE
-  GIT_TAG           origin/stable
+  GIT_TAG           5694f21c39f3b948d06a0c63b9c219bf802e28a8
   GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(experimental_mdspan)

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -249,8 +249,6 @@ message(STATUS "triSYCL kernel trace:             ${TRISYCL_TRACE_KERNEL}")
 
 find_package(Threads REQUIRED)
 
-find_package(range-v3 REQUIRED)
-
 # Install the experimental mdspan implementation described in ISO C++
 # P0009 proposal
 # https://github.com/ORNL/cpp-proposals-pub/tree/master/P0009
@@ -264,6 +262,17 @@ FetchContent_Declare(experimental_mdspan
   GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(experimental_mdspan)
+
+# Get directly a recent version of range-v3 at the source because
+# there are some issues with some old versions provided as
+# distribution packages
+FetchContent_Declare(range_v3
+  GIT_REPOSITORY    https://github.com/ericniebler/range-v3
+  GIT_SHALLOW       TRUE
+  GIT_TAG           0487cca29e352e8f16bbd91fda38e76e39a0ed28
+  GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(range_v3)
 
 #######################
 #  add_sycl_to_target

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -16,7 +16,7 @@ latest Ubuntu too, just adapt the compiler versions):
 
 .. code:: bash
 
-  sudo apt-get install clang-10 g++-10 libomp-dev libboost-all-dev librange-v3-dev
+  sudo apt-get install clang-11 g++-11 libomp-dev libboost-all-dev
 
 There is nothing else to do for now to use the include files from triSYCL_
 ``include`` directory when compiling a program. Just add a


### PR DESCRIPTION
This avoids some issues with old versions provided as package by some Linux distributions.
Also freeze the version of mdspan used to avoid some random breakage if the API changes upstream.

