### PR TITLE
Use hidden friend comparison operators instead of member functions

### DIFF
--- a/include/triSYCL/detail/shared_ptr_implementation.hpp
+++ b/include/triSYCL/detail/shared_ptr_implementation.hpp
@@ -58,9 +58,12 @@ struct shared_ptr_implementation : public boost::totally_ordered<Parent> {
       This is generalized by boost::equality_comparable from
       boost::totally_ordered to implement the equality comparable
       concept
+
+      Use recipe for hidden friends from P1601R0: "Recommendations for
+      Specifying “Hidden Friends""
   */
-  bool operator ==(const Parent &other) const {
-    return implementation == other.implementation;
+  friend bool operator ==(const Parent& lhs, const Parent& rhs) {
+    return lhs.implementation == rhs.implementation;
   }
 
 
@@ -70,10 +73,13 @@ struct shared_ptr_implementation : public boost::totally_ordered<Parent> {
       boost::totally_ordered to implement the equality comparable
       concept
 
+      Use recipe for hidden friends from P1601R0: "Recommendations for
+      Specifying “Hidden Friends""
+
       \todo Add this to the spec
   */
-  bool operator <(const Parent &other) const {
-    return implementation < other.implementation;
+  friend bool operator <(const Parent& lhs, const Parent& rhs) {
+    return lhs.implementation < rhs.implementation;
   }
 
 

--- a/tests/jacobi/include/stencil-var.hpp
+++ b/tests/jacobi/include/stencil-var.hpp
@@ -224,7 +224,7 @@ public:
         cl::sycl::accessor<T, 2, cl::sycl::access::mode::read> _aB {*aB, cgh};
         cl::sycl::accessor<T, 1, cl::sycl::access::mode::read> _bB {*bB, cgh};
         cgh.parallel_for<class KernelCompute>(range,
-                                              [=, *this](cl::sycl::id<2> id){
+                                              [=](cl::sycl::id<2> id){
             operation_var2D<T, B, f, st, aB, bB, a_f, b_f>::eval(id, _B, _aB, _bB);
           });
       });


### PR DESCRIPTION
Follow WG21 P1601R0 "Recommendations for Specifying “Hidden Friends”"
from Walter E. Brown & Daniel Sunderland.

This removes compilation warnings like:
```c++
.../triSYCL/include/triSYCL/device_selector/detail/device_selector_tail.hpp:98:18: warning:
      ISO C++20 considers use of overloaded operator '==' (with operand types 'const trisycl::device' and
      'const trisycl::device') to be ambiguous despite there being a unique best viable function
      [-Wambiguous-reversed-operator]
      return dev == default_device ? 1 : -1;
```
Also remove a useless capture of `this`.
