### PR TITLE
Add an include directory with only triSYCL in it to avoid conflicts

### DIFF
--- a/include-triSYCL-only/triSYCL
+++ b/include-triSYCL-only/triSYCL
@@ -1,0 +1,1 @@
+../include/triSYCL


### PR DESCRIPTION
When combining some triSYCL extensions on top of other
implementations, we do not want that, according to how the include
directories are ordered, some triSYCL sycl/sycl.hpp or CL/sycl.hpp
are picked instead of the one from the other implementations.