### PR TITLE
Update to mdspan P0009r17 proposing now dextents

### DIFF
--- a/include/triSYCL/accessor/mixin/accessor.hpp
+++ b/include/triSYCL/accessor/mixin/accessor.hpp
@@ -69,7 +69,7 @@ template <typename T, int Dimensions> class accessor {
 
  public:
   /// Pointer type to element
-  using pointer = typename mdspan::pointer;
+  using pointer = typename mdspan::accessor_type::data_handle_type;
 
   /// Pointer type to const element
   using const_pointer = const element_type*;
@@ -130,7 +130,7 @@ template <typename T, int Dimensions> class accessor {
   std::size_t get_size() const { return get_count() * sizeof(value_type); }
 
   /// Get the underlying storage
-  auto data() { return access.data(); }
+  auto data() { return access.data_handle(); }
 
   /** Proxy object to transform an expression like
       accessor[i1][i2][i3] into the implementation mdpsan(i1,i2,i3)

--- a/include/triSYCL/accessor/mixin/accessor.hpp
+++ b/include/triSYCL/accessor/mixin/accessor.hpp
@@ -43,26 +43,9 @@ template <typename T, int Dimensions> class accessor {
   static auto constexpr rank() { return Dimensions; }
 
  protected:
-  /* Create an mdspan std::experimental::extents object with a
-     dynamic size for each extent
-
-     \todo Useless since https://isocpp.org/files/papers/P2299R3.html
-     has been implemented
-  */
-  template <std::size_t... I>
-  static constexpr auto make_dynamic_extents(std::index_sequence<I...>) {
-    return std::experimental::extents
-        // This repeats n times the std::experimental::dynamic_extent
-        <((void)I, std::experimental::dynamic_extent)...> {};
-  };
-
-  /// Create an mdspan std::experimental::extents type with a
-  /// dynamic size for each extent
-  using dynamic_extents =
-      decltype(make_dynamic_extents(std::make_index_sequence<Dimensions> {}));
-
   /// The memory lay-out of a buffer is a dynamic multidimensional array
-  using mdspan = std::experimental::mdspan<element_type, dynamic_extents>;
+  using mdspan = std::experimental::mdspan<
+      element_type, std::experimental::dextents<std::size_t, Dimensions>>;
 
   /** This is the multi-dimensional interface to the data that may point
       to either allocation in the case of storage managed by SYCL itself

--- a/include/triSYCL/buffer/detail/buffer.hpp
+++ b/include/triSYCL/buffer/detail/buffer.hpp
@@ -212,7 +212,7 @@ class buffer
            memory instead */
         mixin::update(allocation, current_range);
         // Then copy the read-only data to the new allocated place
-        std::uninitialized_copy_n(current_access.data(), mixin::get_count(),
+        std::uninitialized_copy_n(current_access.data_handle(), mixin::get_count(),
                                   mixin::data());
         /* Now the data of the buffer is no longer backed-up by host
            user provided memory */


### PR DESCRIPTION
Follow latest `mdspan` implementing https://isocpp.org/files/papers/P2299R3.html so the usage is simplified.
`mdspan` implementation has renamed `pointer` and `data()` members.
Use `data_handle_type` and `data_handle()` instead.