### PR TITLE
Avoid derailing the sycl::kernel into the generic parallel_for

### DIFF
--- a/include/triSYCL/handler.hpp
+++ b/include/triSYCL/handler.hpp
@@ -258,6 +258,8 @@ public:
   */
   template <typename KernelName = std::nullptr_t, int Dims,
             typename ParallelForFunctor>
+  // Do not land here if we are using the sycl::kernel API
+  requires (!std::is_base_of_v<kernel, ParallelForFunctor>)
   void parallel_for(const range<Dims>& global_size, ParallelForFunctor f) {
     if constexpr (detail::use_native_work_item) {
       // Use a normal parallel for
@@ -325,6 +327,8 @@ public:
   */
   template <typename KernelName = std::nullptr_t,
             typename ParallelForFunctor>
+  // Do not land here if we are using the sycl::kernel API
+  requires (!std::is_base_of_v<kernel, ParallelForFunctor>)
   void parallel_for(std::size_t global_size,
                     ParallelForFunctor f) {
     parallel_for<KernelName>(range { global_size }, f);

--- a/include/triSYCL/handler.hpp
+++ b/include/triSYCL/handler.hpp
@@ -459,18 +459,18 @@ public:
       to have host fall-back
   */
   void single_task(kernel sycl_kernel) {
-    /* For now just use the usual host task system to schedule          \
-       manually the OpenCL kernels instead of using OpenCL event-based  \
-       scheduling                                                       \
-                                                                        \
-       \todo Move the tracing inside the kernel implementation          \
-                                                                        \
-       \todo Simplify this 2 step ugly interface                        \
-    */                                                                  \
-    task->set_kernel(sycl_kernel.implementation);                       \
-    task->schedule(detail::trace_kernel<kernel>([=, t = task] {         \
-          sycl_kernel.implementation->single_task(t, t->get_queue());   \
-        }));                                                            \
+    /* For now just use the usual host task system to schedule
+       manually the OpenCL kernels instead of using OpenCL event-based
+       scheduling
+
+       \todo Move the tracing inside the kernel implementation
+
+       \todo Simplify this 2 step ugly interface
+    */
+    task->set_kernel(sycl_kernel.implementation);
+    task->schedule(detail::trace_kernel<kernel>([=, t = task] {
+          sycl_kernel.implementation->single_task(t, t->get_queue());
+        }));
   }
 
 

--- a/include/triSYCL/range.hpp
+++ b/include/triSYCL/range.hpp
@@ -9,6 +9,7 @@
     License. See LICENSE.TXT for details.
 */
 
+#include <concepts>
 #include <functional>
 #include <numeric>
 #include <type_traits>
@@ -69,6 +70,14 @@ range(BasicType... Args) -> range<sizeof...(Args)>;
 /// @} End the parallelism Doxygen group
 
 namespace detail {
+    /** Make an explicit range<1> when an integral is provided or pass
+        the value unchanged */
+    auto rangeify(auto r) {
+      if constexpr (std::integral<decltype(r)>)
+        return range { r };
+      else
+        return r;
+    };
 
 /// A type trait to check if a type it a sycl::range or not
 template <typename T> struct is_range : std::false_type {};


### PR DESCRIPTION
After generalizing the code for any dimension, some default paths were
wrongly used when using sycl::kernel instead of kernel callable.