### PR TITLE
Add C++23 mdspan-like indexing and tuple protocol on accessors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TRISYCL_VERSION
   "${TRISYCL_VERSION_MAJOR}.${TRISYCL_VERSION_MINOR}.${TRISYCL_VERSION_PATCH}")
 
 project(triSYCL VERSION ${TRISYCL_VERSION} LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to use")
+set(CMAKE_CXX_STANDARD 23 CACHE STRING "C++ standard to use")
 
 # Pick the Release build type if not defined (to have range-v3 happy)
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")

--- a/cmake/FindtriSYCL.cmake
+++ b/cmake/FindtriSYCL.cmake
@@ -24,7 +24,7 @@ project(triSYCL CXX)
 #  Sets the specified target to support the required C++ standard level.
 #
 #  targetName : Name of the target to be set.
-#  cxxStdYear : The year of the required C++ standard (e.g.: 20)
+#  cxxStdYear : The year of the required C++ standard (e.g.: 23)
 #
 function(set_target_cxx_std targetName cxxStdYear)
   if(cxx_std_${cxxStdYear} IN_LIST CMAKE_CXX_COMPILE_FEATURES)
@@ -68,7 +68,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   else()
     message(STATUS "host compiler - gcc ${CMAKE_CXX_COMPILER_VERSION}")
 
-    set_target_cxx_std(_trisycl_cxxfeatures 20)
+    set_target_cxx_std(_trisycl_cxxfeatures 23)
     target_compile_options(_trisycl_cxxfeatures
       INTERFACE
         # Turn on all warnings:
@@ -95,7 +95,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   else()
     message(STATUS "host compiler - clang ${CMAKE_CXX_COMPILER_VERSION}")
 
-    set_target_cxx_std(_trisycl_cxxfeatures 20)
+    set_target_cxx_std(_trisycl_cxxfeatures 23)
     target_compile_options(_trisycl_cxxfeatures
       INTERFACE
         # Turn on all warnings
@@ -127,7 +127,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # Change to /std:c++latest once Boost::funtional is fixed
   # (1.63.0 with toolset v141 not working)
-  set_target_cxx_std(_trisycl_cxxfeatures 20)
+  set_target_cxx_std(_trisycl_cxxfeatures 23)
   # Replace default Warning Level 3 with 4 (/Wall is pretty-much useless on MSVC
   # system headers are plagued with warnings)
   string(REGEX REPLACE "/W[0-9]" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
@@ -191,7 +191,7 @@ set(CL_SYCL_LANGUAGE_VERSION 121 CACHE STRING VERSION
   "Host language version to be used by triSYCL (default is: 121)")
 set(TRISYCL_CL_LANGUAGE_VERSION 121 CACHE STRING VERSION
   "Device language version to be used by triSYCL (default is: 121)")
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CXX_STANDARD_REQUIRED ON)
 
 if(NOT TRISYCL_INCLUDE_DIR)

--- a/include/CL/sycl.hpp
+++ b/include/CL/sycl.hpp
@@ -7,6 +7,9 @@
     triSYCL into the \c ::cl::sycl namespace
 */
 
+/// Define what is the real SYCL namespace to use
+#define TRISYCL_SYCL_NAMESPACE cl::sycl
+
 #include "triSYCL/sycl.hpp"
 
 /// The official SYCL 1.2.1 specification exposes the API in the

--- a/include/sycl/sycl.hpp
+++ b/include/sycl/sycl.hpp
@@ -9,6 +9,9 @@
 */
 
 
+/// Define what is the real SYCL namespace to use
+#define TRISYCL_SYCL_NAMESPACE sycl
+
 #include "triSYCL/sycl.hpp"
 
 /// Expose the SYCL API directly in the ::sycl namespace

--- a/include/triSYCL/accessor.hpp
+++ b/include/triSYCL/accessor.hpp
@@ -227,34 +227,28 @@ class accessor
     return implementation->get_size();
   }
 
-
-  /** Use the accessor with integers à la [][][]
-
-      \return decltype(auto) to return either a reference to the final
-      element when the indexing has been fully resolved or a proxy
-      object to handle the remaining []
-  */
-  decltype(auto) operator[](std::size_t index) {
-     return (*implementation)[index];
-  }
-
-
-  /** Use the accessor with integers à la [][][]
+  /** Use the accessor with integers à la [i1][i2][i3] or C++23 [i1, i2,...]
 
       \return decltype(auto) to return either a reference to the final
       element when the indexing has been fully resolved or a proxy
-      object to handle the remaining []
-   */
-  decltype(auto) operator[](std::size_t index) const {
-    return (*implementation)[index];
+      object to handle the remaining [] */
+  template <std::integral... T> decltype(auto) operator[](T... indices) {
+    return (*implementation)[indices...];
   }
 
+  /** Use the accessor with integers à la [i1][i2][i3] or C++23 [i1, i2,...]
+
+      \return decltype(auto) to return either a reference to the final
+      element when the indexing has been fully resolved or a proxy
+      object to handle the remaining [] */
+  template <std::integral... T> decltype(auto) operator[](T... indices) const {
+    return (*implementation)[indices...];
+  }
 
   /// To use the accessor with [id<>]
   auto& operator[](const id<dimensionality>& index) {
     return (*implementation)[index];
   }
-
 
   /// To use the accessor with [id<>]
   auto& operator[](const id<dimensionality>& index) const {

--- a/include/triSYCL/accessor/facade/accessor.hpp
+++ b/include/triSYCL/accessor/facade/accessor.hpp
@@ -35,26 +35,36 @@ template <typename AccessorMixIn> class accessor : public AccessorMixIn {
   using reverse_iterator = typename std::reverse_iterator<iterator>;
   using const_reverse_iterator = typename std::reverse_iterator<const_iterator>;
 
-  /** Use the accessor with integers à la [][][]
+  /** Use the accessor with integers à la [i1][i2][i3] or C++23 [i1, i2,...]
 
       \return decltype(auto) to return either a reference to the final
       element when the indexing has been fully resolved or a proxy
       object to handle the remaining [] */
-  decltype(auto) operator[](std::size_t index) {
-    /* Use a proxy object to track all the [index] and aggregate them
-       to resolve the indexing */
-    return typename mixin::template track_index<1> { mixin::access }[index];
+  template <std::integral... T> decltype(auto) operator[](T... indices) {
+    if constexpr (sizeof...(T) == 1)
+      /* The [][][] case uses a proxy object to track all the [index]
+         and aggregate them to resolve the indexing */
+      return
+          typename mixin::template track_index<1> { mixin::access }[indices...];
+    else
+      // Or just the C++23 [i1, i2,...] case
+      return mixin::access[indices...];
   }
 
-  /** Use the accessor with integers à la [][][]
+  /** Use the accessor with integers à la [i1][i2][i3] or C++23 [i1, i2,...]
 
       \return decltype(auto) to return either a reference to the final
       element when the indexing has been fully resolved or a proxy
       object to handle the remaining [] */
-  decltype(auto) operator[](std::size_t index) const {
-    /* Use a proxy object to track all the [index] and aggregate them
-       to resolve the indexing */
-    return typename mixin::template track_index<1> { mixin::access }[index];
+  template <std::integral... T> decltype(auto) operator[](T... indices) const {
+    if constexpr (sizeof...(T) == 1)
+      /* The [][][] case uses a proxy object to track all the [index]
+         and aggregate them to resolve the indexing */
+      return
+          typename mixin::template track_index<1> { mixin::access }[indices...];
+    else
+      // Or just the C++23 [i1, i2,...] case
+      return mixin::access[indices...];
   }
 
   /// To use the accessor with [id<>]

--- a/include/triSYCL/accessor/facade/accessor.hpp
+++ b/include/triSYCL/accessor/facade/accessor.hpp
@@ -58,46 +58,46 @@ template <typename AccessorMixIn> class accessor : public AccessorMixIn {
   }
 
   /// To use the accessor with [id<>]
-  auto& operator[](const id<mixin::rank()>& index) {
-    return mixin::access(mixin::extents_cast(index));
+  decltype(auto) operator[](const id<mixin::rank()>& index) {
+    return mixin::tuple_indexed_access(index);
   }
 
   /// To use the accessor with [id<>]
-  auto& operator[](const id<mixin::rank()>& index) const {
-    return mixin::access(mixin::extents_cast(index));
+  decltype(auto) operator[](const id<mixin::rank()>& index) const {
+    return mixin::tuple_indexed_access(index);
   }
 
   /// To use an accessor with [item<>]
-  auto& operator[](const item<mixin::rank()>& index) {
-    return mixin::access(mixin::extents_cast(index.get()));
+  decltype(auto) operator[](const item<mixin::rank()>& index) {
+    return (*this)[index.get()];
   }
 
   /// To use an accessor with [item<>]
-  auto& operator[](const item<mixin::rank()>& index) const {
-    return mixin::access(mixin::extents_cast(index.get()));
+  decltype(auto) operator[](const item<mixin::rank()>& index) const {
+    return (*this)[index.get()];
   }
 
   /** To use an accessor with an [nd_item<>]
 
-      \todo Add in the specification because used by HPC-GPU slide 22
+      \todo Add to the specification because used by HPC-GPU slide 22
   */
-  auto& operator[](const nd_item<mixin::rank()>& index) {
-    return mixin::access(mixin::extents_cast(index.get_global()));
+  decltype(auto) operator[](const nd_item<mixin::rank()>& index) {
+    return (*this)[index.get_global()];
   }
 
   /** To use an accessor with an [nd_item<>]
 
-      \todo Add in the specification because used by HPC-GPU slide 22
+      \todo Add to the specification because used by HPC-GPU slide 22
   */
-  auto& operator[](const nd_item<mixin::rank()>& index) const {
-    return mixin::access(mixin::extents_cast(index.get_global()));
+  decltype(auto) operator[](const nd_item<mixin::rank()>& index) const {
+    return (*this)[index.get_global()];
   }
 
   /** Get the first element of the accessor
 
       Useful with an accessor on a scalar for example.
 
-      \todo Add in the specification
+      \todo Add to the specification
   */
   typename mixin::reference operator*() { return *mixin::data(); }
 
@@ -105,7 +105,7 @@ template <typename AccessorMixIn> class accessor : public AccessorMixIn {
 
       Useful with an accessor on a scalar for example.
 
-      \todo Add in the specification?
+      \todo Add to the specification?
 
       \todo Add the concept of 0-dim buffer and accessor for scalar
       and use an implicit conversion to value_type reference to access

--- a/include/triSYCL/accessor/mixin/accessor.hpp
+++ b/include/triSYCL/accessor/mixin/accessor.hpp
@@ -144,14 +144,10 @@ template <typename T, int Dimensions> class accessor {
   static decltype(auto)
   tuple_indexed_mdspan_access(auto&& some_mdspan,
                               const auto& tuple_like_indices) {
-    if constexpr (requires { std::invoke(some_mdspan, tuple_like_indices); })
-      // If we have the pre-C++23 mdspan(i1, i2,...) indexing syntax, use it
-      return std::invoke(some_mdspan, tuple_like_indices);
-    else
-      // Otherwise use the C++23 mdspan[i1, i2,...] indexing syntax
-      return std::invoke(
-          [&](auto... i) -> decltype(auto) { return some_mdspan[i...]; },
-          tuple_like_indices);
+    // Otherwise use the C++23 mdspan[i1, i2,...] indexing syntax
+    return std::invoke(
+        [&](auto... i) -> decltype(auto) { return some_mdspan[i...]; },
+        tuple_like_indices);
   }
 
   /** Access to an element with indices implementing a tuple

--- a/include/triSYCL/accessor/mixin/accessor.hpp
+++ b/include/triSYCL/accessor/mixin/accessor.hpp
@@ -132,6 +132,39 @@ template <typename T, int Dimensions> class accessor {
   /// Get the underlying storage
   auto data() { return access.data_handle(); }
 
+  /** Access to an mdspan element with indices implementing a tuple
+      interface
+
+      \param[inout] some_mdspan is the mdspan to access
+
+      \param[in] tuple_like_indices are the indices to use
+
+      \return a reference to the element
+  */
+  static decltype(auto)
+  tuple_indexed_mdspan_access(auto&& some_mdspan,
+                              const auto& tuple_like_indices) {
+    if constexpr (requires { std::invoke(some_mdspan, tuple_like_indices); })
+      // If we have the pre-C++23 mdspan(i1, i2,...) indexing syntax, use it
+      return std::invoke(some_mdspan, tuple_like_indices);
+    else
+      // Otherwise use the C++23 mdspan[i1, i2,...] indexing syntax
+      return std::invoke(
+          [&](auto... i) -> decltype(auto) { return some_mdspan[i...]; },
+          tuple_like_indices);
+  }
+
+  /** Access to an element with indices implementing a tuple
+      interface
+
+      \param[in] tuple_like_indices are the indices to use
+
+      \return a reference to the accessor element
+  */
+  decltype(auto) tuple_indexed_access(const auto& tuple_like_indices) {
+    return tuple_indexed_mdspan_access(access, tuple_like_indices);
+  }
+
   /** Proxy object to transform an expression like
       accessor[i1][i2][i3] into the implementation mdpsan(i1,i2,i3)
       one index at a time.
@@ -168,7 +201,7 @@ template <typename T, int Dimensions> class accessor {
       if constexpr (N == accessor::rank())
         // If we have accumulated all the indices, call the mdspan
         // indexing function
-        return std::invoke(mds, indices);
+        return tuple_indexed_mdspan_access(mds, indices);
       else
         // Otherwise return a tracker from the current indices and
         // with 1 more room for the next index

--- a/include/triSYCL/detail/array_tuple_helpers.hpp
+++ b/include/triSYCL/detail/array_tuple_helpers.hpp
@@ -41,7 +41,7 @@ tuple_to_array_iterate(Tuple t, std::index_sequence<Is...>) {
      The static cast is here to avoid the warning when there is a loss
      of precision, for example when initializing an int from a float.
   */
-  return { { static_cast<typename V::element_type>(std::get<Is>(t))...} };
+  return { { static_cast<typename V::element_type>(std::get<Is>(t))... } };
 }
 
 

--- a/include/triSYCL/detail/global_config.hpp
+++ b/include/triSYCL/detail/global_config.hpp
@@ -37,6 +37,11 @@ namespace trisycl::detail {
 #endif
     ;
 
+/// Define what is the real SYCL namespace to use
+#ifndef TRISYCL_SYCL_NAMESPACE
+#define TRISYCL_SYCL_NAMESPACE trisycl
+#endif
+
   /// Map TRISYCL_USE_OPENCL_ND_RANGE to a constexpr variable
   constexpr bool use_native_work_item =
 #ifdef TRISYCL_USE_OPENCL_ND_RANGE

--- a/include/triSYCL/id.hpp
+++ b/include/triSYCL/id.hpp
@@ -74,27 +74,6 @@ template <typename... BasicType> id(BasicType... Args) -> id<sizeof...(Args)>;
 
 }
 
-namespace std {
-// Declare a tuple-like interface for the sycl::id
-
-/// Export the id dimension as its tuple size
-template <int Dimensions> struct tuple_size<trisycl::id<Dimensions>>
-    : public std::integral_constant<std::size_t, Dimensions> {};
-
-/// The element of the tuple is the matching id element
-template <std::size_t I, int Dimensions>
-decltype(auto) get(trisycl::id<Dimensions>&& id) {
-  return id.get(I);
-}
-
-/// Each tuple element type is the same, the one of any id element
-template <std::size_t I, int Dimensions>
-struct tuple_element<I, trisycl::id<Dimensions>> {
-  using type = typename trisycl::id<Dimensions>::element_type;
-};
-
-}
-
 /*
     # Some Emacs stuff:
     ### Local Variables:

--- a/include/triSYCL/id.hpp
+++ b/include/triSYCL/id.hpp
@@ -11,6 +11,8 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <tuple>
+#include <type_traits>
 
 #include "triSYCL/detail/small_array.hpp"
 #include "triSYCL/range.hpp"
@@ -69,6 +71,27 @@ public:
 template <typename... BasicType> id(BasicType... Args) -> id<sizeof...(Args)>;
 
 /// @} End the parallelism Doxygen group
+
+}
+
+namespace std {
+// Declare a tuple-like interface for the sycl::id
+
+/// Export the id dimension as its tuple size
+template <int Dimensions> struct tuple_size<trisycl::id<Dimensions>>
+    : public std::integral_constant<std::size_t, Dimensions> {};
+
+/// The element of the tuple is the matching id element
+template <std::size_t I, int Dimensions>
+decltype(auto) get(trisycl::id<Dimensions>&& id) {
+  return id.get(I);
+}
+
+/// Each tuple element type is the same, the one of any id element
+template <std::size_t I, int Dimensions>
+struct tuple_element<I, trisycl::id<Dimensions>> {
+  using type = typename trisycl::id<Dimensions>::element_type;
+};
 
 }
 

--- a/tests/address_spaces/address_spaces_pstl.cpp
+++ b/tests/address_spaces/address_spaces_pstl.cpp
@@ -2,12 +2,11 @@
 */
 
 #include <CL/sycl.hpp>
-#include <vector>
-#include <list>
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
-
+#include <list>
+#include <tuple>
 
 
 size_t up_rounded_division(size_t x, size_t y){
@@ -242,7 +241,8 @@ int main() {
 {
   std::vector<int> v1 = {2, 2, 3, 1};
   std::vector<int> v2 = {4, 2, 1, 3};
-  int result = 18;
+  int constexpr result = 18;
+  std::ignore = result;
   int value = 0;
 
   value = std::inner_product(v1.begin(), v1.end(), v2.begin(), value);
@@ -253,7 +253,8 @@ int main() {
 {
   std::vector<int> v1 = {2, 2, 3, 1};
   std::vector<int> v2 = {4, 2, 1, 3};
-  int result = 28;
+  int constexpr result = 28;
+  std::ignore = result;
   int value = 10;
 
   cl::sycl::queue q;
@@ -265,7 +266,8 @@ int main() {
 {
   std::vector<int> v1 = {2, 2, 3, 1, 5, 1, 1, 1};
   std::vector<int> v2 = {4, 2, 1, 3, 5, 1, 1, 1};
-  int result = 46;
+  int constexpr result = 46;
+  std::ignore = result;
   int value = 0;
 
   cl::sycl::queue q;
@@ -277,7 +279,8 @@ int main() {
 {
   std::vector<int> v1 = {2, 2, 3, 1, 5, 1, 1};
   std::vector<int> v2 = {4, 2, 1, 3, 5, 1, 1};
-  int result = 45;
+  int constexpr result = 45;
+  std::ignore = result;
   int value = 0;
 
   cl::sycl::queue q;
@@ -289,7 +292,8 @@ int main() {
 {
   std::vector<int> v1 = {2, 2, 3, 1};
   std::vector<int> v2 = {4, 2, 1, 3};
-  int result = 28;
+  int constexpr result = 28;
+  std::ignore = result;
   int value = 10;
 
   cl::sycl::queue q;
@@ -303,7 +307,8 @@ int main() {
 {
   std::vector<float> v1 = {2.0, 2.0, 3.0, 1.0};
   std::vector<float> v2 = {4.0, 2.0, 1.0, 3.0};
-  float result = 28.0;
+  float constexpr result = 28.0;
+  std::ignore = result;
   float value = 10.0;
 
   cl::sycl::queue q;
@@ -317,7 +322,8 @@ int main() {
 {
   std::list<float> v1;  //{2.0, 2.0, 3.0, 1.0};
   std::list<float> v2;  //{4.0, 2.0, 1.0, 3.0};
-  float result = 28.0;
+  float constexpr result = 28.0;
+  std::ignore = result;
   float value = 10.0;
 
   v1.push_back(2.0);

--- a/tests/common/test-helpers.hpp
+++ b/tests/common/test-helpers.hpp
@@ -4,11 +4,11 @@
 /// Define a level of multi-dimensional iterator
 template <int Dimensions, typename Functor, std::size_t level>
 struct trisycl_for_range_iterate {
-  trisycl_for_range_iterate(const cl::sycl::range<Dimensions> &r,
-                            cl::sycl::id<Dimensions> &it,
+  trisycl_for_range_iterate(const TRISYCL_SYCL_NAMESPACE::range<Dimensions> &r,
+                            TRISYCL_SYCL_NAMESPACE::id<Dimensions> &it,
                             const Functor &f) {
     // Iterate in dimension level
-    using value_type = typename cl::sycl::id<Dimensions>::value_type;
+    using value_type = typename TRISYCL_SYCL_NAMESPACE::id<Dimensions>::value_type;
     for (value_type i = 0; r[level - 1] - i != 0; ++i) {
       // Set current dimension
       it[level - 1] = i;
@@ -22,8 +22,8 @@ struct trisycl_for_range_iterate {
 /// Once at level 0, just call the final function with the current coordinate
 template <int Dimensions, typename Functor>
 struct trisycl_for_range_iterate<Dimensions, Functor, 0> {
-  trisycl_for_range_iterate(const cl::sycl::range<Dimensions> &r,
-                            cl::sycl::id<Dimensions> &it,
+  trisycl_for_range_iterate(const TRISYCL_SYCL_NAMESPACE::range<Dimensions> &r,
+                            TRISYCL_SYCL_NAMESPACE::id<Dimensions> &it,
                             const Functor &f) {
     f(it);
   }
@@ -33,16 +33,16 @@ struct trisycl_for_range_iterate<Dimensions, Functor, 0> {
 /// Apply a function on all the id<> of a range<>
 template <int Dimensions, typename Functor>
 void
-trisycl_for_range(const cl::sycl::range<Dimensions> &r,
+trisycl_for_range(const TRISYCL_SYCL_NAMESPACE::range<Dimensions> &r,
                   const Functor &f) {
-  cl::sycl::id<Dimensions> it;
+  TRISYCL_SYCL_NAMESPACE::id<Dimensions> it;
   trisycl_for_range_iterate<Dimensions, Functor, Dimensions>(r, it, f);
 }
 
 /// Output an id<> on a stream
 template <int Dimensions>
 std::ostream& operator<<(std::ostream& stream,
-                         const cl::sycl::id<Dimensions>& i) {
+                         const TRISYCL_SYCL_NAMESPACE::id<Dimensions>& i) {
   for (auto e : i)
     stream<< e << " ";
   return stream;
@@ -52,14 +52,14 @@ std::ostream& operator<<(std::ostream& stream,
 /// Verify the value of a buffer against a function of the id<>
 template <typename dataType,
           int Dimensions,
-          cl::sycl::access::mode mode,
-          cl::sycl::access::target target,
+          TRISYCL_SYCL_NAMESPACE::access::mode mode,
+          TRISYCL_SYCL_NAMESPACE::access::target target,
           typename Functor>
 bool trisycl_verify_buffer_value(
-    cl::sycl::buffer<dataType, Dimensions> b,
-    cl::sycl::accessor<dataType, Dimensions, mode, target> a,
+    TRISYCL_SYCL_NAMESPACE::buffer<dataType, Dimensions> b,
+    TRISYCL_SYCL_NAMESPACE::accessor<dataType, Dimensions, mode, target> a,
     Functor f) {
-  trisycl_for_range(b.get_range(), [&] (cl::sycl::id<Dimensions> i) {
+  trisycl_for_range(b.get_range(), [&] (TRISYCL_SYCL_NAMESPACE::id<Dimensions> i) {
       if (a[i] != f(i)) {
         std::stringstream message;
         message << "Error: got " << a[i] << " instead of expected " << f(i)
@@ -88,7 +88,7 @@ bool trisycl_verify_buffer_value(
   do {                                                                  \
     try {                                                               \
       trisycl_verify_buffer_value(b,                                    \
-                                  b.get_access<cl::sycl::access::mode::read>(), \
+                                  b.get_access<TRISYCL_SYCL_NAMESPACE::access::mode::read>(), \
                                   func);                                \
     }                                                                   \
     catch (std::runtime_error &e) {                                     \

--- a/tests/id/CMakeLists.txt
+++ b/tests/id/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required (VERSION 3.0) # The minimum version of CMake necessary to build this project
-project (id) # The name of our project
+project(id)
 
 declare_trisycl_test(TARGET id TEST_REGEX
 "Result:
@@ -23,8 +22,11 @@ cjj via e = 3
  1 2 3
  5 6
 zeroid = 0, 0, 0")
+
 declare_trisycl_test(TARGET id_any_dimension CATCH2_WITH_MAIN TEST_REGEX
 " 1 2 3 4
  2 4 7 12
  1 2 3 4 5
  7 8 9 10 11 12")
+
+declare_trisycl_test(TARGET tuple_like_protocol CATCH2_WITH_MAIN)

--- a/tests/id/id_any_dimension.cpp
+++ b/tests/id/id_any_dimension.cpp
@@ -3,6 +3,7 @@
    Example using extension for SYCL objects with dimensions higher than 3
 */
 
+// Allows also ranks higher than 3
 #define TRISYCL_ALLOW_ANY_DIMENSION
 
 #include <sycl/sycl.hpp>
@@ -14,7 +15,7 @@ TEST_CASE("use dimensions higher than 3", "[id]") {
   // CTAD
   sycl::id i5 { 0, 1, 2, 3, 4 };
   i5.display();
-  
+
   sycl::id<4> i4;
   i4 = { 1, 2, 3, 4 };
   i4.display();

--- a/tests/id/tuple_like_protocol.cpp
+++ b/tests/id/tuple_like_protocol.cpp
@@ -1,0 +1,45 @@
+/* RUN: %{execute}%s | %{filecheck} %s
+
+   Check tuple-like protocol of sycl::id
+*/
+
+#include <sycl/sycl.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+
+TEST_CASE("test the tuple-like protocol", "[id]") {
+  // CTAD
+  sycl::id i { 1, 2, 3 };
+  REQUIRE(std::get<0>(i) == 1);
+  REQUIRE(std::get<1>(i) == 2);
+  REQUIRE(std::get<2>(i) == 3);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<0, decltype(i)>>);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<1, decltype(i)>>);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<2, decltype(i)>>);
+  {
+    auto [x, y, z] = i;
+    REQUIRE(x == 1);
+    REQUIRE(y == 2);
+    REQUIRE(z == 3);
+    ++x;
+    --y;
+    ++z;
+    REQUIRE((i == sycl::id { 1, 2, 3 }));
+  }
+  {
+    auto& [x, y, z] = i;
+    REQUIRE(x == 1);
+    REQUIRE(y == 2);
+    REQUIRE(z == 3);
+    ++x;
+    --y;
+    ++z;
+    REQUIRE((i == sycl::id { 2, 1, 4 }));
+  }
+}

--- a/tests/parallel_for/CMakeLists.txt
+++ b/tests/parallel_for/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(parallel_for) # The name of our project
 
 declare_trisycl_test(TARGET capture_scalars)
+declare_trisycl_test(TARGET generalized_dimension CATCH2_WITH_MAIN)
 declare_trisycl_test(TARGET hierarchical_new CATCH2_WITH_MAIN)
 declare_trisycl_test(TARGET hierarchical CATCH2_WITH_MAIN)
 declare_trisycl_test(TARGET initializer_list)

--- a/tests/parallel_for/generalized_dimension.cpp
+++ b/tests/parallel_for/generalized_dimension.cpp
@@ -1,0 +1,31 @@
+/* RUN: %{execute}%s
+
+   Generalize the dimension number and use modern C++ features like
+   - tuple-interface to id and range;
+   - C++23 mdspan addressing.
+*/
+#include <iostream>
+
+// Allows also ranks higher than 3
+#define TRISYCL_ALLOW_ANY_DIMENSION
+
+#include "sycl/sycl.hpp"
+#include "test-helpers.hpp"
+
+int main() {
+  {
+    sycl::queue q;
+
+    sycl::buffer<int, 4> a { { 2, 3, 5, 7 } };
+
+    q.submit([&](sycl::handler& cgh) {
+      sycl::accessor acc { a, cgh };
+      cgh.parallel_for(a.get_range(), [=](sycl::id<4> i) {
+        auto [x, y, z, t] = i;
+        acc[x, y, z, t] = x + y + z + t;
+      });
+    });
+    VERIFY_BUFFER_VALUE(a, [](sycl::id<4> i) { return i[0] + i[1] + i[2] + i[3]; });
+  return 0;
+  }
+}

--- a/tests/range/CMakeLists.txt
+++ b/tests/range/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(range) # The name of our project
+project(range)
 
 declare_trisycl_test(TARGET range TEST_REGEX
 "Result:
@@ -33,4 +33,7 @@ d = 2,4,4
  1 2 3
  0 1 2
  1 2 3")
+
 declare_trisycl_test(TARGET range_size CATCH2_WITH_MAIN)
+
+declare_trisycl_test(TARGET tuple_like_protocol CATCH2_WITH_MAIN)

--- a/tests/range/tuple_like_protocol.cpp
+++ b/tests/range/tuple_like_protocol.cpp
@@ -1,0 +1,45 @@
+/* RUN: %{execute}%s | %{filecheck} %s
+
+   Check tuple-like protocol of sycl::range
+*/
+
+#include <sycl/sycl.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <iostream>
+#include <tuple>
+#include <type_traits>
+
+TEST_CASE("test the tuple-like protocol", "[range]") {
+  // CTAD
+  sycl::range i { 1, 2, 3 };
+  REQUIRE(std::get<0>(i) == 1);
+  REQUIRE(std::get<1>(i) == 2);
+  REQUIRE(std::get<2>(i) == 3);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<0, decltype(i)>>);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<1, decltype(i)>>);
+  static_assert(
+      std::is_same_v<std::size_t, std::tuple_element_t<2, decltype(i)>>);
+  {
+    auto [x, y, z] = i;
+    REQUIRE(x == 1);
+    REQUIRE(y == 2);
+    REQUIRE(z == 3);
+    ++x;
+    --y;
+    ++z;
+    REQUIRE((i == sycl::range { 1, 2, 3 }));
+  }
+  {
+    auto& [x, y, z] = i;
+    REQUIRE(x == 1);
+    REQUIRE(y == 2);
+    REQUIRE(z == 3);
+    ++x;
+    --y;
+    ++z;
+    REQUIRE((i == sycl::range { 2, 1, 4 }));
+  }
+}


### PR DESCRIPTION
Now it is possible to write code like:
```c++
int main() {
  {
    sycl::queue q;

    sycl::buffer<int, 4> a { { 2, 3, 5, 7 } };

    q.submit([&](sycl::handler& cgh) {
      sycl::accessor acc { a, cgh };
      cgh.parallel_for(a.get_range(), [=](sycl::id<4> i) {
        auto [x, y, z, t] = i;
        acc[x, y, z, t] = x + y + z + t;
      });
    });
    VERIFY_BUFFER_VALUE(a, [](sycl::id<4> i) { return i[0] + i[1] + i[2] + i[3]; });
  return 0;
  }
}
```