### PR TITLE
Use Ubuntu 23.04, Clang 17 ToT and update for latest mdspan

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,13 @@ jobs:
     # cross-platform coverage.
     # See:
     # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.10
+
+    # Be sure to pick an OS from
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+    # otherwise the job will be stuck for ever in "Waiting for a
+    # runner to pick up this job... " for a non existing runner to
+    # come.
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out repository code
@@ -61,7 +67,7 @@ jobs:
   docker:
     name: Run the validation inside Docker with specific OS and options
 
-    runs-on: ubuntu-22.10
+    runs-on: ubuntu-22.04
 
     strategy:
       # Run all the test even if there are some which fail
@@ -79,13 +85,13 @@ jobs:
            OpenMP: ON
            OpenCL: ON
 
-         - c_compiler: clang-15
-           cxx_compiler: clang++-15
+         - c_compiler: clang-16
+           cxx_compiler: clang++-16
            OpenMP: ON
            OpenCL: OFF
 
-         - c_compiler: clang-15
-           cxx_compiler: clang++-15
+         - c_compiler: clang-16
+           cxx_compiler: clang++-16
            OpenMP: ON
            OpenCL: ON
 
@@ -95,8 +101,8 @@ jobs:
 
       - name: ${{ matrix.c_compiler }}, ${{ matrix.cxx_compiler }},
           OpenMP=${{ matrix.OpenMP }}, OpenCL=${{ matrix.OpenCL }}
-          in Docker Ubuntu 22.10
-        uses: docker://ubuntu:jammy
+          in Docker Ubuntu 23.04
+        uses: docker://ubuntu:lunar
         env:
           C_COMPILER: ${{ matrix.c_compiler }}
           CXX_COMPILER: ${{ matrix.cxx_compiler }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,13 +85,13 @@ jobs:
            OpenMP: ON
            OpenCL: ON
 
-         - c_compiler: clang-16
-           cxx_compiler: clang++-16
+         - c_compiler: clang-17
+           cxx_compiler: clang++-17
            OpenMP: ON
            OpenCL: OFF
 
-         - c_compiler: clang-16
-           cxx_compiler: clang++-16
+         - c_compiler: clang-17
+           cxx_compiler: clang++-17
            OpenMP: ON
            OpenCL: ON
 

--- a/.github/workflows/run_ci_in_docker.bash
+++ b/.github/workflows/run_ci_in_docker.bash
@@ -49,9 +49,17 @@ $APT_INSTALL git apt-utils cmake libboost-all-dev \
 # Clang/LLVM by adding the repository from https://apt.llvm.org/ to
 # benefit from https://reviews.llvm.org/D149637
 if [[ $C_COMPILER =~ ^clang || $CXX_COMPILER =~ ^clang++ ]]; then
-  # Add tools used to set-up the LLVM repository configuration
-  $APT_INSTALL lsb-release wget software-properties-common gnupg
-  bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+  # Tools to set-up the LLVM repository authentication
+  $APT_INSTALL wget
+  wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+    tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+  # "Parse" the Linux distribution parameters
+  source /etc/os-release
+  echo "deb http://apt.llvm.org/$VERSION_CODENAME llvm-toolchain-$VERSION_CODENAME main" \
+    > /etc/apt/sources.list.d/llvm.list
+  echo "deb-src http://apt.llvm.org/$VERSION_CODENAME llvm-toolchain-$VERSION_CODENAME main" \
+    >> /etc/apt/sources.list.d/llvm.list
+  apt update
 fi
 
 # Install the required C compiler:

--- a/.github/workflows/run_ci_in_docker.bash
+++ b/.github/workflows/run_ci_in_docker.bash
@@ -49,6 +49,8 @@ $APT_INSTALL git apt-utils cmake libboost-all-dev \
 # Clang/LLVM by adding the repository from https://apt.llvm.org/ to
 # benefit from https://reviews.llvm.org/D149637
 if [[ $C_COMPILER =~ ^clang || $CXX_COMPILER =~ ^clang++ ]]; then
+  # Add tools used to set-up the LLVM repository configuration
+  $APT_INSTALL lsb-release wget software-properties-common gnupg
   bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 fi
 

--- a/.github/workflows/run_ci_in_docker.bash
+++ b/.github/workflows/run_ci_in_docker.bash
@@ -45,11 +45,14 @@ APT_INSTALL="apt-get install $APT_ENABLE"
 $APT_INSTALL git apt-utils cmake libboost-all-dev \
   librange-v3-dev
 
-# Install the required C compiler:g
+# Install the required C compiler:
 $APT_INSTALL $C_COMPILER
 
 # Install the required C++ compiler.
 if [[ $CXX_COMPILER =~ ^clang++ ]]; then
+  # Install the latest Clang/LLVM https://apt.llvm.org/
+  # to benefit from https://reviews.llvm.org/D149637
+  bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
   if [[ $OPENMP == ON ]]; then
     # Clang requires a specific OpenMP library to run.
     # The version is what is left when we remove "clang++-"

--- a/.github/workflows/run_ci_in_docker.bash
+++ b/.github/workflows/run_ci_in_docker.bash
@@ -45,14 +45,18 @@ APT_INSTALL="apt-get install $APT_ENABLE"
 $APT_INSTALL git apt-utils cmake libboost-all-dev \
   librange-v3-dev
 
+# If clang or clang++ is required, prepare to install the latest
+# Clang/LLVM by adding the repository from https://apt.llvm.org/ to
+# benefit from https://reviews.llvm.org/D149637
+if [[ $C_COMPILER =~ ^clang || $CXX_COMPILER =~ ^clang++ ]]; then
+  bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+fi
+
 # Install the required C compiler:
 $APT_INSTALL $C_COMPILER
 
 # Install the required C++ compiler.
 if [[ $CXX_COMPILER =~ ^clang++ ]]; then
-  # Install the latest Clang/LLVM https://apt.llvm.org/
-  # to benefit from https://reviews.llvm.org/D149637
-  bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
   if [[ $OPENMP == ON ]]; then
     # Clang requires a specific OpenMP library to run.
     # The version is what is left when we remove "clang++-"

--- a/include/triSYCL/accessor/mixin/accessor.hpp
+++ b/include/triSYCL/accessor/mixin/accessor.hpp
@@ -44,8 +44,8 @@ template <typename T, int Dimensions> class accessor {
 
  protected:
   /// The memory lay-out of a buffer is a dynamic multidimensional array
-  using mdspan = std::experimental::mdspan<
-      element_type, std::experimental::dextents<std::size_t, Dimensions>>;
+  using mdspan = std::mdspan<
+      element_type, std::dextents<std::size_t, Dimensions>>;
 
   /** This is the multi-dimensional interface to the data that may point
       to either allocation in the case of storage managed by SYCL itself

--- a/include/triSYCL/buffer/detail/accessor.hpp
+++ b/include/triSYCL/buffer/detail/accessor.hpp
@@ -40,8 +40,8 @@ template <typename T, int Dimensions> class buffer;
 /** The buffer accessor abstracts the way buffer data are accessed
     inside a kernel in a multidimensional variable length array way.
 
-    This implementation relies on std::experimental::mdspan to provide
-    this nice syntax and behavior.
+    This implementation relies on std::mdspan to provide this nice
+    syntax and behavior.
 
     Right now the aim of this class is just to access to the buffer in
     a read-write mode, even if capturing the accessor from a lambda

--- a/tests/math/vector_math.cpp
+++ b/tests/math/vector_math.cpp
@@ -80,6 +80,7 @@ inline void do_check_sign() {
                                           uint32_t{1} << 31};
 
   for (std::size_t i = 0; i < 8; ++i) {
+    std::cerr << i << ' ' << res[i] << ' ' << expected_output[i] << std::endl;
     REQUIRE(reinterpret_cast<uint32_t &>(res[i]) == expected_output[i]);
   }
 }


### PR DESCRIPTION
Clang 15 crashes on the code, so use a distribution providing a more modern version.
Actually the bug was only fixed recently with https://reviews.llvm.org/D149637 and https://reviews.llvm.org/D150008.
Also update `mdspan` namespace to remove `experimental::` now it landed in C++23.