### PR TITLE
Add compilation timeout for partial compilation to ccache

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,6 +50,14 @@ jobs:
       # Ubuntu 23.04
       image: docker://ubuntu:lunar
 
+    # Cancel old CI jobs for a PR when the PR is updated
+    concurrency:
+      # Create a job equivalence class with an id crafted to only
+      # cancel in-progress runs of the same workflow
+      group: ${{ github.workflow }}-${{ github.ref }}
+      # Cancel only pull-request related events
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
     strategy:
       # Run all the test even if there are some which fail
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,13 @@ on:
         required: false
         default: 10
 
+defaults:
+  run:
+    # This is already the default, except when running inside another Docker
+    # image, which is the case here. So set it up globally to avoid
+    # repeating elsewhere.
+    shell: bash
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
@@ -125,7 +132,6 @@ jobs:
 
       - name: Declare LLVM package repository if needed
         if: ${{ startsWith(matrix.c_compiler, 'clang') || startsWith(matrix.cxx_compiler, 'clang') }}
-        shell: bash
         run: |
           apt-get install -y wget
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -149,7 +155,6 @@ jobs:
       - name: Install OpenMP support if needed
         # Clang requires a specific OpenMP library to run
         if: ${{ matrix.OpenMP == 'ON' && startsWith(matrix.cxx_compiler, 'clang') }}
-        shell: bash
         run: |
           # Get the clang++ version, which is what is left when we remove "clang++-"
           CXX_COMPILER=${{matrix.cxx_compiler}}
@@ -161,7 +166,11 @@ jobs:
         run: apt-get install -y opencl-headers ocl-icd-opencl-dev libpocl-dev
 
       # Use ccache to speed-up compilation to also fit into GitHub Actions
-      # resource limitations https://github.com/hendrikmuhs/ccache-action
+      # resource limitations, see:
+      # https://github.com/hendrikmuhs/ccache-action
+      # The cache is saved in a "Post install-ccache" step, even if
+      # the job is canceled or some previous step fails, which is good
+      # to avoid wasting constrained compilation resources
       - name: install-ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,8 +86,9 @@ jobs:
     # Cancel old CI jobs for a PR when the PR is updated
     concurrency:
       # Create a job equivalence class with an id crafted to only
-      # cancel in-progress runs of the same workflow
-      group: ${{ github.workflow }}-${{ github.ref }}
+      # cancel in-progress runs of the same workflow and same
+      # job-index in the matrix
+      group: '${{ github.workflow }}-job-index-${{ strategy.job-index }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }} for ${{ matrix }}'
       # Cancel only pull-request related events
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
@@ -99,6 +100,8 @@ jobs:
         run: |
           echo "::notice::{github context:}"
           echo "${{ toJSON(github) }}"
+          echo "::notice::{env context:}"
+          echo "${{ toJSON(env) }}"
           echo "::notice::{vars context:}"
           echo "${{ toJSON(vars) }}"
           echo "::notice::{job context:}"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,14 +50,6 @@ jobs:
       # Ubuntu 23.04
       image: docker://ubuntu:lunar
 
-    # Cancel old CI jobs for a PR when the PR is updated
-    concurrency:
-      # Create a job equivalence class with an id crafted to only
-      # cancel in-progress runs of the same workflow
-      group: ${{ github.workflow }}-${{ github.ref }}
-      # Cancel only pull-request related events
-      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
     strategy:
       # Run all the test even if there are some which fail
       fail-fast: false
@@ -84,7 +76,43 @@ jobs:
            OpenMP: ON
            OpenCL: ON
 
+    # Cancel old CI jobs for a PR when the PR is updated
+    concurrency:
+      # Create a job equivalence class with an id crafted to only
+      # cancel in-progress runs of the same workflow
+      group: ${{ github.workflow }}-${{ github.ref }}
+      # Cancel only pull-request related events
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
     steps:
+      - name: Execution context information
+        # Display a lot of information to help further development
+        # https://docs.github.com/en/actions/learn-github-actions/variables
+        # https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/contexts
+        run: |
+          echo "::notice::{github context:}"
+          echo "${{ toJSON(github) }}"
+          echo "::notice::{vars context:}"
+          echo "${{ toJSON(vars) }}"
+          echo "::notice::{job context:}"
+          echo "${{ toJSON(job) }}"
+          echo "::notice::{steps context:}"
+          echo "${{ toJSON(steps) }}"
+          echo "::notice::{runner context:}"
+          echo "${{ toJSON(runner) }}"
+          echo "::notice::{strategy context:}"
+          echo "${{ toJSON(strategy) }}"
+          echo "::notice::{matrix context:}"
+          echo "${{ toJSON(matrix) }}"
+          echo "::notice::{needs context:}"
+          echo "${{ toJSON(needs) }}"
+          echo "::notice::{inputs context:}"
+          echo "${{ toJSON(inputs) }}"
+          echo github.workflow=${{ github.workflow }}
+          echo github.ref=${{ github.ref }}
+          echo Shell environment variables:
+          env
+
       - name: Check out repository code
         uses: actions/checkout@v3
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,12 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
+      compilation_time_out:
+        type: string
+        description: Run the build with a timeout in minutes to have
+          partial compilation to bootstrap ccache
+        required: false
+        default: 10
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -136,6 +142,7 @@ jobs:
 
       - name: Build for ${{matrix.c_compiler}}, ${{matrix.cxx_compiler}},
           OpenMP=${{matrix.OpenMP}}, OpenCL=${{matrix.OpenCL}}
+        timeout-minutes: ${{ inputs.compilation_time_out }}
         # Compile all the tests using all the available cores
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
           --verbose --parallel `nproc`


### PR DESCRIPTION
The problem is when the CI compilation time does not fit into the
default GitHub limits, the job is killed and ccache action cannot even
save its compilation cache for next CI execution.
So add an optional timeout usable from the manual launch to stop the
compilation before the deadline so ccache can save the partial compilation.
Also add some output about the execution context to help debug.